### PR TITLE
Update navbar to not use a function removed from the PyData Sphinx Theme.

### DIFF
--- a/docs/_templates/navbar.html
+++ b/docs/_templates/navbar.html
@@ -9,15 +9,16 @@
     </a>
   
     <div id="navbar-menu" class="collapse navbar-collapse">
-      <ul id="navbar-main-elements" class="navbar-nav mr-auto">
-        {% set nav = get_nav_object(maxdepth=1, collapse=True) %}
-        {% for main_nav_item in nav %}
-        <li class="nav-item {% if main_nav_item.active%}active{% endif %}">
-            <a class="nav-link" href="{{ main_nav_item.url }}">{{ main_nav_item.title }}</a>
+      <ul id="navbar-main-elements" class="navbar-nav">
+        {{ generate_nav_html("navbar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) }}
+        {% for external_link in theme_external_links %}
+        <li class="nav-item">
+            <a class="nav-link nav-external" href="{{ external_link.url }}">{{ _(external_link.name) }}<i class="fas fa-external-link-alt"></i></a>
         </li>
         {% endfor %}
       </ul>
     </div>
+
 
     <a class="navbar-brand" href="https://www.deltares.nl/en/">
     <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo" />


### PR DESCRIPTION
The `get_nav_object()` function was removed in the PyData Sphinx theme version 7.0.

This fix uses the newer more generic `generate_nav_html()` to do the same.