### PR TITLE
Add test from weights with layered

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from tests.fixtures.fixture_regridder import (
     disk,
+    disk_layered,
     expected_results_centroid,
     expected_results_linear,
     expected_results_overlap,

--- a/tests/fixtures/fixture_regridder.py
+++ b/tests/fixtures/fixture_regridder.py
@@ -24,6 +24,14 @@ def disk():
 
 
 @pytest.fixture(scope="function")
+def disk_layered(disk):
+    layer = xr.DataArray([1.0, 2.0, 3.0], coords={"layer": [1, 2, 3]}, dims=("layer",))
+    # Disk is first in multiplication, to ensure that object is promoted to UgridDataArray
+    disk_layered = disk * layer
+    return disk_layered.transpose("layer", disk.ugrid.grid.face_dimension)
+
+
+@pytest.fixture(scope="function")
 def quads_0_25():
     dx = 0.25
     xmin, ymin, xmax, ymax = xu.data.disk().ugrid.total_bounds

--- a/tests/test_regrid/test_regridder.py
+++ b/tests/test_regrid/test_regridder.py
@@ -165,6 +165,25 @@ def test_regridder_from_weights(cls, disk, quads_1):
         BarycentricInterpolator,
     ],
 )
+def test_regridder_from_weights_layered(cls, disk, disk_layered, quads_1):
+    square = quads_1
+    regridder = cls(source=disk, target=square)
+    result = regridder.regrid(disk)
+    weights = regridder.weights
+    new_regridder = cls.from_weights(weights, target=square)
+    new_result = new_regridder.regrid(disk_layered)
+    assert new_result.equals(result.sel(layer=1))
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        CentroidLocatorRegridder,
+        OverlapRegridder,
+        RelativeOverlapRegridder,
+        BarycentricInterpolator,
+    ],
+)
 def test_regridder_from_dataset(cls, disk, quads_1):
     square = quads_1
     regridder = cls(source=disk, target=square)


### PR DESCRIPTION
I added a small test which fails with v0.5.0, but worked with v0.4.0. 

Something happened in this merge, which broke this functionality:
https://github.com/Deltares/xugrid/pull/76/files

It is causing 2 failures in the iMOD Python test bench:
https://gitlab.com/deltares/imod/imod-python/-/issues/397
