### PR TITLE
avoid hardcoded _FillValue and replacing fillvalue in cast

### DIFF
--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -259,7 +259,6 @@ class Ugrid2d(AbstractUgrid):
             + list(connectivity.values())
             + list(chain.from_iterable(chain.from_iterable(coordinates.values())))
         )
-        fill_value = -1
 
         x_index = coordinates["node_coordinates"][0][0]
         y_index = coordinates["node_coordinates"][1][0]
@@ -267,6 +266,10 @@ class Ugrid2d(AbstractUgrid):
         node_y_coordinates = ds[y_index].astype(FloatDType).values
 
         face_nodes = connectivity["face_node_connectivity"]
+        if '_FillValue' in ds[face_nodes].encoding.keys():
+            fill_value = ds[face_nodes].encoding['_FillValue']
+        else:
+            fill_value = -1
         face_node_connectivity = cls._prepare_connectivity(
             ds[face_nodes], fill_value, dtype=IntDType
         ).values

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -381,6 +381,7 @@ class AbstractUgrid(abc.ABC):
         cast = data.astype(dtype, copy=True)
         if start_index:
             cast -= start_index
+        cast[is_fill] = fill_value
         if (cast[~is_fill] < 0).any():
             raise ValueError("connectivity contains negative values")
         return da.copy(data=cast)


### PR DESCRIPTION
This is a minimal fix for https://github.com/Deltares/xugrid/issues/113. This issue was introduced by fixing https://github.com/Deltares/xugrid/issues/101