### PR TITLE
Fix issue when using relative overlap regridder for structured grids

### DIFF
--- a/tests/test_regrid/test_structured.py
+++ b/tests/test_regrid/test_structured.py
@@ -69,6 +69,18 @@ def test_overlap_1d(
     assert np.array_equal(source[sorter], np.array([0, 0, 1, 1]))
     assert np.array_equal(target[sorter], np.array([0, 1, 1, 2]))
     assert np.array_equal(weights[sorter], np.array([17.5, 32.5, 17.5, 25.0]))
+    
+    # relative
+    # --------
+    # source   targets  weight
+    # node 0   0, 1     17.5 m, 32.5 m
+    # node 1   1, 2     17.5 m, 25.0 m
+    # --------
+    source, target, weights = grid_data_a_1d.overlap(grid_data_e_1d, relative=True)
+    sorter = np.argsort(source)
+    assert np.array_equal(source[sorter], np.array([0, 0, 1, 1]))
+    assert np.array_equal(target[sorter], np.array([0, 1, 1, 2]))
+    assert np.array_equal(weights[sorter], np.array([17.5/50.0, 32.5/50.0, 17.5/50.0, 25.0/50.0]))
 
 
 def test_overlap_2d(grid_data_a_2d, grid_data_b_2d):

--- a/xugrid/regrid/structured.py
+++ b/xugrid/regrid/structured.py
@@ -90,7 +90,7 @@ class StructuredGrid1d:
 
     @property
     def length(self) -> FloatArray:
-        return abs(np.diff(self.bounds, axis=1))
+        return np.squeeze(abs(np.diff(self.bounds, axis=1)))
 
     def flip_if_needed(self, index: IntArray) -> IntArray:
         if self.flipped:
@@ -339,7 +339,7 @@ class StructuredGrid1d:
         """
         source_index, target_index, weights = self.overlap_1d_structured(other)
         if relative:
-            weights /= self.length()[source_index]
+            weights /= self.length[source_index]
         return self.sorted_output(source_index, target_index, weights)
 
     def locate_centroids(


### PR DESCRIPTION
length property of structured 1d-class is not callable since its a property + squeeze extra dimension of length (result of bounding box second axis)