### PR TITLE
Fix arrangement of test_infer_bounds_errors after xarray v2023.08.0

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -208,7 +208,8 @@ def test_infer_bounds(
 
 def test_infer_bounds_errors(structured_mesh_ascending):
     up = structured_mesh_ascending
-    up["x"].values[2] = 3.0
+    up = up.assign_coords(x=[2.0, 4.0, 3.0, 8.0])
+
     with pytest.raises(ValueError, match="x is not monotonic"):
         cv.infer_bounds(up, "x")
 


### PR DESCRIPTION
[A test is failing](https://github.com/Deltares/xugrid/actions/runs/5938758920/job/16103843774) due to the most recent xarray v2023.08.0 update. Apparently the indexes attribute is not updated anymore when setting values on coordinates as follows:

```python
up = xr.DataArray(
        data=np.arange(4),
        coords={"x": [2.0, 4.0, 6.0, 8.0]},
        dims=["x"],
        name="grid",
    )

up["x"].values[2] = 3.0

print(up["x"].indexes)
# up["x"].indexes not updated
```

But this works:

```python
up = up.assign_coords(x = [2.0, 4.0, 3.0, 8.0])

print(up["x"].indexes)
# up["x"].indexes are updated
```

[It turns out the first example is not what the xarray devs have in mind on how coords should be set](https://github.com/pydata/xarray/issues/7463#issuecomment-1428391853), so this explains why this test is failing without this fix.
