### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Xugrid (pronounced "kiss you grid" by `visionaries 🗢
   fig, (ax0, ax1) = plt.subplots(figsize=(22.6, 10), ncols=2)
   uda.ugrid.plot(ax=ax0, vmin=-20, vmax=90, cmap="terrain")
   ax0.axhline(y=section_y, color="red")
-  section.plot(ax=ax1, x="mesh2d_x")
+  section.plot(ax=ax1, x="mesh2d_face_x")
 
 .. image:: https://raw.githubusercontent.com/Deltares/xugrid/main/docs/_static/xugrid-demo.png
   :target: https://github.com/deltares/xugrid


### PR DESCRIPTION
I needed to change this line to 

    section.plot(ax=ax1, x="mesh2d_face_x")

because of this error:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[197], line 15
     13 uda.ugrid.plot(ax=ax0, vmin=-20, vmax=90, cmap="terrain")
     14 ax0.axhline(y=section_y, color="red")
---> 15 section.plot(ax=ax1, x="mesh2d_x")

File ~/anaconda3/envs/leafletNetcdf_2/lib/python3.11/site-packages/xarray/plot/accessor.py:47, in DataArrayPlotAccessor.__call__(self, **kwargs)
     45 @functools.wraps(dataarray_plot.plot, assigned=("__doc__", "__annotations__"))
     46 def __call__(self, **kwargs) -> Any:
---> 47     return dataarray_plot.plot(self._da, **kwargs)

File ~/anaconda3/envs/leafletNetcdf_2/lib/python3.11/site-packages/xarray/plot/dataarray_plot.py:306, in plot(darray, row, col, col_wrap, ax, hue, subplot_kws, **kwargs)
    302     plotfunc = hist
    304 kwargs["ax"] = ax
--> 306 return plotfunc(darray, **kwargs)

File ~/anaconda3/envs/leafletNetcdf_2/lib/python3.11/site-packages/xarray/plot/dataarray_plot.py:500, in line(darray, row, col, figsize, aspect, size, ax, hue, x, y, xincrease, yincrease, xscale, yscale, xticks, yticks, xlim, ylim, add_legend, _labels, *args, **kwargs)
    497     assert "args" not in kwargs
    499 ax = get_axis(figsize, size, aspect, ax)
--> 500 xplt, yplt, hueplt, hue_label = _infer_line_data(darray, x, y, hue)
    502 # Remove pd.Intervals if contained in xplt.values and/or yplt.values.
    503 xplt_val, yplt_val, x_suffix, y_suffix, kwargs = _resolve_intervals_1dplot(
    504     xplt.to_numpy(), yplt.to_numpy(), kwargs
    505 )

File ~/anaconda3/envs/leafletNetcdf_2/lib/python3.11/site-packages/xarray/plot/dataarray_plot.py:71, in _infer_line_data(darray, x, y, hue)
     68     raise ValueError("Cannot specify both x and y kwargs for line plots.")
     70 if x is not None:
---> 71     _assert_valid_xy(darray, x, "x")
     73 if y is not None:
     74     _assert_valid_xy(darray, y, "y")

File ~/anaconda3/envs/leafletNetcdf_2/lib/python3.11/site-packages/xarray/plot/utils.py:442, in _assert_valid_xy(darray, xy, name)
    440 if (xy is not None) and (xy not in valid_xy):
    441     valid_xy_str = "', '".join(sorted(tuple(str(v) for v in valid_xy)))
--> 442     raise ValueError(
    443         f"{name} must be one of None, '{valid_xy_str}'. Received '{xy}' instead."
    444     )

ValueError: x must be one of None, 'mesh2d_face_x', 'mesh2d_face_y', 'mesh2d_nFaces', 's', 'x', 'y'. Received 'mesh2d_x' instead.
```