### PR TITLE
Reindex

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,7 +27,7 @@ Added
   :meth:`xugrid.Ugrid2d.reindex_like`,
   :meth:`xugrid.UgridDataArrayAccessor.reindex_like` and
   :meth:`xugrid.UgridDatasetAccessor.reindex_like` have been added to deal with
-  equivalent but differently ordered topologies.
+  equivalent but differently ordered topologies and data.
 
 Changed
 ~~~~~~~
@@ -37,6 +37,14 @@ Changed
 
 Fixed
 ~~~~~
+
+- Using an index which only reorders but does not change the size in
+  :meth:`xugrid.Ugrid1d.topology_subset` or
+  :meth:`xugrid.Ugrid2d.topology_subset` would erroneously result in the
+  original grid being returned, rather than a new grid with the faces or edges
+  shuffled. This breaks the link the between topology and data when using
+  ``.isel`` on a UgridDataset or UgridDataArray. This has been fixed: both data
+  and the topology are now shuffled accordingly. 
 
 [0.6.5] 2023-09-30
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,11 @@ Added
   ordinary grid to a periodic grid.
 - :attr:`xugrid.Ugrid2d.perimeter` has been added the compute the length of the
   face perimeters.
+- :meth:`xugrid.Ugrid1d.reindex_like`,
+  :meth:`xugrid.Ugrid2d.reindex_like`,
+  :meth:`xugrid.UgridDataArrayAccessor.reindex_like` and
+  :meth:`xugrid.UgridDatasetAccessor.reindex_like` have been added to deal with
+  equivalent but differently ordered topologies.
 
 Changed
 ~~~~~~~

--- a/examples/partitioning.py
+++ b/examples/partitioning.py
@@ -110,8 +110,18 @@ uda == merged
 
 # %%
 # The topology is equivalent, but the nodes, edges, and faces are in a
-# different order. This is because ``merge_partitions`` concatenates the
-# partitions. To preserve order, we can assign an ID to the partitions, and
+# different order. This is because ``merge_partitions`` simply concatenates the
+# partitions.
+#
+# The easiest way to restore the order is by providing an example of the
+# original topology. ``reindex_like`` looks at the coordinates of both
+# (equivalent!) grids and automatically determines how to reorder:
+
+reordered = merged.ugrid.reindex_like(uda)
+uda == reordered
+
+# %%
+# Alternatively, we can also assign IDs, carry these along, and use these to
 # reorder the data after merging.
 
 uds = xu.UgridDataset(grids=[uda.ugrid.grid])

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -52,13 +52,19 @@ def test_argsort_rows():
 
 def test_index_like():
     xy_a = np.array([[0.0, 0.0], [1.0, 1.0]])
+    xy_b = np.array([[0.0, 0.0]])
+    with pytest.raises(ValueError, match="coordinates do not match in shape"):
+        connectivity.index_like(xy_a, xy_b, tolerance=0.0)
+
     xy_b = np.array([[0.0, 0.0], [1.1, 1.0]])
     with pytest.raises(ValueError, match="coordinates are not identical after sorting"):
-        connectivity.index_like(xy_a, xy_b)
+        connectivity.index_like(xy_a, xy_b, tolerance=0.0)
+    # Now with higher tolerance
+    connectivity.index_like(xy_a, xy_b, tolerance=0.2)
 
     xy_a = np.array([[3.0, 3.0], [1.0, 1.0], [2.0, 2.0], [0.0, 0.0]])
     xy_b = np.array([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0], [2.0, 2.0]])
-    actual = connectivity.index_like(xy_a, xy_b)
+    actual = connectivity.index_like(xy_a, xy_b, tolerance=0.0)
     expected = [3, 1, 0, 2]
     assert np.array_equal(actual, expected)
 

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -31,6 +31,38 @@ def mixed_mesh():
     return faces, fill_value
 
 
+def test_argsort_rows():
+    with pytest.raises(ValueError, match="Array is not 2D"):
+        connectivity.argsort_rows(np.array([3, 2, 1, 0]))
+
+    array = np.array(
+        [
+            [1, 0],
+            [0, 1],
+            [2, 2],
+            [2, 1],
+            [0, 2],
+            [2, 0],
+        ]
+    )
+    _, expected = np.unique(array, axis=0, return_index=True)
+    actual = connectivity.argsort_rows(array)
+    assert np.array_equal(actual, expected)
+
+
+def test_index_like():
+    xy_a = np.array([[0.0, 0.0], [1.0, 1.0]])
+    xy_b = np.array([[0.0, 0.0], [1.1, 1.0]])
+    with pytest.raises(ValueError, match="coordinates are not identical after sorting"):
+        connectivity.index_like(xy_a, xy_b)
+
+    xy_a = np.array([[3.0, 3.0], [1.0, 1.0], [2.0, 2.0], [0.0, 0.0]])
+    xy_b = np.array([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0], [2.0, 2.0]])
+    actual = connectivity.index_like(xy_a, xy_b)
+    expected = [3, 1, 0, 2]
+    assert np.array_equal(actual, expected)
+
+
 def test_neighbors():
     i = [0, 0, 0, 1, 1, 1]
     j = [0, 1, 2, 1, 3, 2]

--- a/tests/test_ugrid1d.py
+++ b/tests/test_ugrid1d.py
@@ -330,6 +330,15 @@ def test_topology_subset():
     assert np.array_equal(actual.node_y, [1.0, 2.0])
 
 
+def test_reindex_like():
+    grid = grid1d()
+    index = np.array([1, 0])
+    reordered = grid.topology_subset(index)
+    obj = xr.DataArray(index, dims=(reordered.edge_dimension))
+    reindexed = reordered.reindex_like(grid, obj=obj)
+    assert np.array_equal(reindexed, [0, 1])
+
+
 def test_ugrid1d_plot():
     grid = grid1d()
     primitive = grid.plot()

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -293,6 +293,12 @@ class TestUgridDataArray:
             assert isinstance(partition, xugrid.UgridDataArray)
             assert partition.name == self.uda.name
 
+    def test_reindex_like(self):
+        back = self.uda.ugrid.reindex_like(self.uda)
+        assert isinstance(back, xugrid.UgridDataArray)
+        back = self.uda.ugrid.reindex_like(self.uda.ugrid.grid)
+        assert isinstance(back, xugrid.UgridDataArray)
+
     def test_crs(self):
         uda = self.uda
         crs = uda.ugrid.crs
@@ -637,6 +643,12 @@ class TestUgridDataset:
             assert "a" in partition
             assert "b" in partition
 
+    def test_reindex_like(self):
+        back = self.uds.ugrid.reindex_like(self.uds)
+        assert isinstance(back, xugrid.UgridDataset)
+        back = self.uds.ugrid.reindex_like(self.uds.ugrid.grid)
+        assert isinstance(back, xugrid.UgridDataset)
+
     def test_crs(self):
         uds = self.uds
         crs = uds.ugrid.crs
@@ -731,6 +743,10 @@ class TestMultiToplogyUgridDataset:
         result = self.uds.ugrid.sel(x=slice(-10, 10), y=slice(-10, 10))
         # Ensure both grids are still present
         assert len(result.ugrid.grids) == 2
+
+    def test_reindex_like(self):
+        back = self.uds.ugrid.reindex_like(self.uds)
+        assert isinstance(back, xugrid.UgridDataset)
 
 
 def test_multiple_coordinates():

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -704,7 +704,7 @@ class TestUgridDataset:
         assert self.uds.ugrid.total_bounds == (0.0, 0.0, 2.0, 2.0)
 
 
-class TestMultiToplogyUgridDataset:
+class TestMultiTopologyUgridDataset:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.uds = xugrid.UgridDataset(grids=GRID())

--- a/xugrid/core/dataarray_accessor.py
+++ b/xugrid/core/dataarray_accessor.py
@@ -420,7 +420,11 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         geometry = self.grid.to_shapely(dim)
         return gpd.GeoDataFrame(df, geometry=geometry, crs=self.grid.crs)
 
-    def reindex_like(self, other: Union[UgridType, UgridDataArray, UgridDataset]):
+    def reindex_like(
+        self,
+        other: Union[UgridType, UgridDataArray, UgridDataset],
+        tolerance: float = 0.0,
+    ):
         """
         Conform this object to match the topology of another object. The
         topologies must be exactly equivalent: only the order of the nodes,
@@ -432,6 +436,8 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         ----------
         other: Ugrid1d, Ugrid2d, UgridDataArray, UgridDataset
         obj: DataArray or Dataset
+        tolerance: float, default value 0.0.
+            Maximum distance between inexact coordinate matches.
 
         Returns
         -------
@@ -446,7 +452,7 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
                 "Expected Ugrid1d, Ugrid2d, UgridDataArray, or UgridDataset,"
                 f"received instead: {type(other).__name__}"
             )
-        new_obj = self.grid.reindex_like(other_grid, obj=self.obj)
+        new_obj = self.grid.reindex_like(other_grid, obj=self.obj, tolerance=tolerance)
         return UgridDataArray(new_obj, other_grid)
 
     def _binary_iterate(self, iterations: int, mask, value, border_value):

--- a/xugrid/core/dataset_accessor.py
+++ b/xugrid/core/dataset_accessor.py
@@ -590,15 +590,15 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
                 "Expected Ugrid1d, Ugrid2d, UgridDataArray, or UgridDataset,"
                 f"received instead: {type(other).__name__}"
             )
-        grids = self.grids
+        # Convert to dict to match by name
         other_grids = {grid.name: grid for grid in other_grids}
 
         new_grids = []
         result = self.obj
-        for grid in grids:
+        for grid in self.grids:
             other = other_grids.get(grid.name)
             if other:
-                result = self.grid.reindex_like(other, obj=result, tolerance=tolerance)
+                result = grid.reindex_like(other, obj=result, tolerance=tolerance)
                 new_grids.append(other)
             else:
                 new_grids.append(grid)

--- a/xugrid/core/dataset_accessor.py
+++ b/xugrid/core/dataset_accessor.py
@@ -557,7 +557,11 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
 
         return pd.concat(gdfs)
 
-    def reindex_like(self, other: Union[UgridType, UgridDataArray, UgridDataset]):
+    def reindex_like(
+        self,
+        other: Union[UgridType, UgridDataArray, UgridDataset],
+        tolerance: float = 0.0,
+    ):
         """
         Conform this object to match the topology of another object. The
         topologies must be exactly equivalent: only the order of the nodes,
@@ -570,6 +574,8 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         ----------
         other: Ugrid1d, Ugrid2d, UgridDataArray, UgridDataset
         obj: DataArray or Dataset
+        tolerance: float, default value 0.0.
+            Maximum distance between inexact coordinate matches.
 
         Returns
         -------
@@ -592,7 +598,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         for grid in grids:
             other = other_grids.get(grid.name)
             if other:
-                result = self.grid.reindex_like(other, obj=result)
+                result = self.grid.reindex_like(other, obj=result, tolerance=tolerance)
                 new_grids.append(other)
             else:
                 new_grids.append(grid)

--- a/xugrid/ugrid/connectivity.py
+++ b/xugrid/ugrid/connectivity.py
@@ -25,16 +25,8 @@ def index_like(xy_a: FloatArray, xy_b: FloatArray, tolerance: float):
 
     sorter_a = argsort_rows(xy_a)
     sorter_b = argsort_rows(xy_b)
-    # This should NOT be allclose even if it's operating on floating point
-    # values: the coordinates should be EXACTLY equal if the topology is just a
-    # shuffled one.
     if not np.allclose(xy_a[sorter_a], xy_b[sorter_b], rtol=0.0, atol=tolerance):
         raise ValueError("coordinates are not identical after sorting")
-    #
-    #   a_to_b
-    # a ------> b
-    #
-    # via:
     #
     #   sorter_a         inverse_b
     # a --------> sorted ---------> b

--- a/xugrid/ugrid/connectivity.py
+++ b/xugrid/ugrid/connectivity.py
@@ -16,16 +16,19 @@ def argsort_rows(array: np.ndarray) -> IntArray:
     return np.argsort(arr1d)
 
 
-def index_like(xy_a: FloatArray, xy_b: FloatArray):
+def index_like(xy_a: FloatArray, xy_b: FloatArray, tolerance: float):
     """
     Return the index that would transform xy_a into xy_b.
     """
+    if xy_a.shape != xy_b.shape:
+        raise ValueError("coordinates do not match in shape")
+
     sorter_a = argsort_rows(xy_a)
     sorter_b = argsort_rows(xy_b)
     # This should NOT be allclose even if it's operating on floating point
     # values: the coordinates should be EXACTLY equal if the topology is just a
     # shuffled one.
-    if not np.array_equal(xy_a[sorter_a], xy_b[sorter_b]):
+    if not np.allclose(xy_a[sorter_a], xy_b[sorter_b], rtol=0.0, atol=tolerance):
         raise ValueError("coordinates are not identical after sorting")
     #
     #   a_to_b

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -615,3 +615,33 @@ class Ugrid1d(AbstractUgrid):
             attrs=grid._attrs,
         )
         return merged_grid, indexes
+
+    def reindex_like(self, other: "Ugrid1d", obj: Union[xr.DataArray, xr.Dataset]):
+        """
+        Conform a DataArray or Dataset to match the topology of another Ugrid1D
+        topology. The topologies must be exactly equivalent: only the order of
+        the nodes and edges may differ.
+
+        Parameters
+        ----------
+        other: Ugrid1d
+        obj: DataArray or Dataset
+
+        Returns
+        -------
+        reindexed: DataArray or Dataset
+        """
+        if not isinstance(other, Ugrid1d):
+            raise TypeError(f"Expected Ugrid1d, received: {type(other).__name__}")
+
+        indexers = {
+            self.node_dimension: connectivity.index_like(
+                xy_a=self.node_coordinates,
+                xy_b=other.node_coordinates,
+            ),
+            self.edge_dimension: connectivity.index_like(
+                xy_a=self.edge_coordinates,
+                xy_b=other.edge_coordinates,
+            ),
+        }
+        return obj.isel(indexers, missing_dims="ignore")

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -145,6 +145,10 @@ class AbstractUgrid(abc.ABC):
     def merge_partitions():
         """ """
 
+    @abc.abstractmethod
+    def reindex_like():
+        """ """
+
     def _initialize_indexes_attrs(self, name, dataset, indexes, attrs):
         defaults = conventions.default_topology_attrs(name, self.topology_dimension)
 


### PR DESCRIPTION
Use the node, edge, face coordinates to find out how to reorder the data to match the order of an other topology.

Fixes #153
