### PR TITLE
Add support for multi-dimensional coordinates in from_structured

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -329,7 +329,10 @@ UGRID2D Topology
     Ugrid2d.to_dataset
     Ugrid2d.from_geodataframe
     Ugrid2d.from_structured
+    Ugrid2d.from_structured_multicoord
     Ugrid2d.from_structured_bounds
+    Ugrid2d.from_structured_intervals1d
+    Ugrid2d.from_structured_intervals2d
     Ugrid2d.from_shapely
     Ugrid2d.to_shapely
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,27 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+Unreleased
+----------
+
+Added
+~~~~~
+
+- :meth:`xugrid.Ugrid2.from_structured_multicoord` has been added
+  to generate UGRID topologies from rotated or approximated curvilinear grids.
+- :meth:`xugrid.Ugrid2d.from_structured_intervals1d` has been added to generate
+  UGRID topologies from "intervals": the N + 1 vertex coordinates for N faces.
+- :meth:`xugrid.Ugrid2d.from_structured_intervals2d` has been added to generate
+  UGRID topologies from "intervals": the (M + 1, N + 1) vertex coordinates for N faces.
+- :meth:`xugrid.UgridDataArrayAccessor.from_structured` now takes ``x`` and ``y``
+  arguments to specify which coordinates to use as the UGRID x and y coordinates.
+
+Changed
+~~~~~~~
+
+- :meth:`xugrid.Ugrid2d.from_structured` now takes ``x`` and ``y`` arguments instead
+  of ``x_bounds`` and ``y_bounds`` arguments.
+
 [0.8.1] 2024-01-19
 ------------------
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -2417,6 +2417,102 @@ package:
   size: 322086
   timestamp: 1695990976742
 - platform: linux-64
+  name: build
+  version: 0.7.0
+  category: main
+  manager: conda
+  dependencies:
+  - importlib-metadata
+  - packaging
+  - pep517 >=0.9.1
+  - python >=3.6
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: add7f31586d03678695b32b78a1337a1
+    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 17759
+  timestamp: 1631843776429
+- platform: osx-64
+  name: build
+  version: 0.7.0
+  category: main
+  manager: conda
+  dependencies:
+  - importlib-metadata
+  - packaging
+  - pep517 >=0.9.1
+  - python >=3.6
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: add7f31586d03678695b32b78a1337a1
+    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 17759
+  timestamp: 1631843776429
+- platform: osx-arm64
+  name: build
+  version: 0.7.0
+  category: main
+  manager: conda
+  dependencies:
+  - importlib-metadata
+  - packaging
+  - pep517 >=0.9.1
+  - python >=3.6
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: add7f31586d03678695b32b78a1337a1
+    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 17759
+  timestamp: 1631843776429
+- platform: win-64
+  name: build
+  version: 0.7.0
+  category: main
+  manager: conda
+  dependencies:
+  - importlib-metadata
+  - packaging
+  - pep517 >=0.9.1
+  - python >=3.6
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: add7f31586d03678695b32b78a1337a1
+    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 17759
+  timestamp: 1631843776429
+- platform: linux-64
   name: bzip2
   version: 1.0.8
   category: main
@@ -4951,6 +5047,86 @@ package:
   size: 972760
   timestamp: 1695301035902
 - platform: linux-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: osx-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: osx-arm64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: win-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: linux-64
   name: exceptiongroup
   version: 1.1.3
   category: main
@@ -7215,6 +7391,114 @@ package:
   license_family: BSD
   size: 97658
   timestamp: 1649144191039
+- platform: linux-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: osx-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: osx-arm64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: win-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
 - platform: linux-64
   name: hdf4
   version: 4.2.15
@@ -18180,6 +18464,86 @@ package:
   size: 20743
   timestamp: 1695667673391
 - platform: linux-64
+  name: pathspec
+  version: 0.12.1
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 41173
+  timestamp: 1702250135032
+- platform: osx-64
+  name: pathspec
+  version: 0.12.1
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 41173
+  timestamp: 1702250135032
+- platform: osx-arm64
+  name: pathspec
+  version: 0.12.1
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 41173
+  timestamp: 1702250135032
+- platform: win-64
+  name: pathspec
+  version: 0.12.1
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 41173
+  timestamp: 1702250135032
+- platform: linux-64
   name: pcre2
   version: '10.40'
   category: main
@@ -18263,6 +18627,90 @@ package:
   license_family: BSD
   size: 2001630
   timestamp: 1665563527916
+- platform: linux-64
+  name: pep517
+  version: 0.13.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d94aa03d99d8adc9898f783eba0d84d2
+    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 19044
+  timestamp: 1667916747996
+- platform: osx-64
+  name: pep517
+  version: 0.13.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d94aa03d99d8adc9898f783eba0d84d2
+    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 19044
+  timestamp: 1667916747996
+- platform: osx-arm64
+  name: pep517
+  version: 0.13.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d94aa03d99d8adc9898f783eba0d84d2
+    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 19044
+  timestamp: 1667916747996
+- platform: win-64
+  name: pep517
+  version: 0.13.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  - tomli
+  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d94aa03d99d8adc9898f783eba0d84d2
+    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 19044
+  timestamp: 1667916747996
 - platform: linux-64
   name: pexpect
   version: 4.8.0
@@ -24882,6 +25330,86 @@ package:
   noarch: python
   size: 109927
   timestamp: 1701095799725
+- platform: linux-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: osx-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: osx-arm64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: win-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
 - platform: linux-64
   name: twine
   version: 4.0.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xugrid"
-version = "0.8.0"
+version = "0.8.1"
 description = "Xarray extension for unstructured grids"
 authors = ["Huite Bootsma <huite.bootsma@deltares.nl>"]
 channels = ["conda-forge"]
@@ -45,3 +45,5 @@ xarray = "*"
 zarr = "*"
 ipykernel = "6.26.0.*"  # So we can run examples
 twine = "*"
+hatchling = "1.21.0.*"
+build = "0.7.0.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,11 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "xugrid"
 description = "Xarray extension for unstructured grids"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-version = "0.8.0"
 maintainers = [{ name = "Huite Bootsma", email = "huite.bootsma@deltares.nl" }]
 requires-python = ">=3.9"
 dependencies = [
@@ -18,6 +17,7 @@ dependencies = [
     'scipy',
     'xarray',
 ]
+dynamic = ["version"]
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Intended Audience :: Science/Research',
@@ -51,32 +51,12 @@ all = [
     'pyproj',
     'zarr',
 ]
-# pyproject.toml doesn't quite support re-use like setup.cfg did:
-# https://github.com/pypa/setuptools/issues/3221
-docs = [
-    'geopandas',
-    'matplotlib',
-    'meshkernel',
-    'netcdf4',
-    'pooch',
-    'pyproj',
-    'shapely >= 2.0',
-    'zarr',
-    'pydata-sphinx-theme',
-    'sphinx',
-    'sphinx-gallery',
-]
 
-[tool.setuptools]
-packages = [
-    "xugrid",
-    "xugrid.core",
-    "xugrid.data",
-    "xugrid.plot",
-    "xugrid.regrid",
-    "xugrid.ugrid",
-]
-license-files = ["LICENSE"]
+[tool.hatch.version]
+path = "xugrid/__init__.py"
+
+[tool.hatch.build.targets.sdist]
+only-include = ["xugrid", "tests"]
 
 [tool.isort]
 profile = "black"

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -979,6 +979,84 @@ def test_meshkernel():
     assert isinstance(grid.meshkernel, mk.MeshKernel)
 
 
+def test_from_structured_intervals1d():
+    grid = xugrid.Ugrid2d.from_structured_intervals1d(
+        x_intervals=[0.0, 1.0, 2.0],
+        y_intervals=[2.0, 1.0, 0.0],
+    )
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 4
+
+
+def test_from_structured_intervals2d():
+    with pytest.raises(ValueError, match="Dimensions of intervals must be 2D."):
+        xugrid.Ugrid2d.from_structured_intervals2d(
+            x_intervals=[0.0, 1.0, 2.0],
+            y_intervals=[2.0, 1.0, 0.0],
+        )
+    with pytest.raises(ValueError, match="Interval shapes must match."):
+        xugrid.Ugrid2d.from_structured_intervals2d(
+            x_intervals=[[0.0, 1.0, 2.0]],
+            y_intervals=[[2.0, 1.0, 0.0, 4.0]],
+        )
+
+    grid = xugrid.Ugrid2d.from_structured_intervals2d(
+        x_intervals=[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        y_intervals=[
+            [2.0, 1.0, 0.0],
+            [2.0, 1.0, 0.0],
+            [2.0, 1.0, 0.0],
+        ],
+    )
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 4
+
+
+def test_from_structured_bounds():
+    x_vertices = np.array([1.0, 3.0, 5.0, 7.0, 9.0])
+    y_vertices = np.array([2.5, 7.5, 12.5, 17.5])
+    # Ascending
+    x_bounds = np.column_stack((x_vertices[:-1], x_vertices[1:]))
+    y_bounds = np.column_stack((y_vertices[:-1], y_vertices[1:]))
+    grid = xugrid.Ugrid2d.from_structured_bounds(x_bounds, y_bounds)
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 12
+
+
+def test_from_structured():
+    da = xr.DataArray(
+        data=np.ones((2, 2)),
+        coords={"y": [12.0, 11.0], "x": [1.0, 2.0]},
+        dims=("y", "x"),
+    )
+    grid = xugrid.Ugrid2d.from_structured(da)
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 4
+
+    da = xr.DataArray(
+        data=np.ones((2, 2)),
+        coords={"lat": [12.0, 11.0], "lon": [1.0, 2.0]},
+        dims=("lat", "lon"),
+    )
+    grid = xugrid.Ugrid2d.from_structured(da, x="lon", y="lat")
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 4
+
+
+def test_form_structured_multicoord():
+    da = xr.DataArray(
+        data=np.ones((2, 2)),
+        coords={
+            "yc": (("y", "x"), [[12.0, 11.0], [12.0, 11.0]]),
+            "xc": (("y", "x"), [[1.0, 2.0], [1.0, 2.0]]),
+        },
+        dims=("y", "x"),
+    )
+    grid = xugrid.Ugrid2d.from_structured(da)
+    assert isinstance(grid, xugrid.Ugrid2d)
+    assert grid.n_face == 4
+
+
 def test_from_shapely():
     with pytest.raises(TypeError):
         x = np.array([0.0, 1.0, 2.0])

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -177,6 +177,25 @@ class TestUgridDataArray:
         uda = xugrid.UgridDataArray.from_structured(flipped)
         assert np.allclose(uda.ugrid.sel(x=2.0, y=5.0), [[0], [12]])
 
+    def test_from_structured_multicoord(self):
+        da = xr.DataArray(
+            data=[[0, 1], [2, 3]],
+            coords={
+                "yc": (("y", "x"), [[12.0, 11.0], [12.0, 11.0]]),
+                "xc": (("y", "x"), [[10.0, 12.0], [10.0, 12.0]]),
+            },
+            dims=("y", "x"),
+        )
+        uda = xugrid.UgridDataArray.from_structured(da)
+        assert isinstance(uda, xugrid.UgridDataArray)
+        assert np.array_equal(np.unique(uda.ugrid.grid.node_x), [-0.5, 0.5, 1.5])
+        assert np.array_equal(uda.data, [0, 1, 2, 3])
+
+        uda = xugrid.UgridDataArray.from_structured(da, x="xc", y="yc")
+        assert isinstance(uda, xugrid.UgridDataArray)
+        assert np.array_equal(np.unique(uda.ugrid.grid.node_x), [9.0, 11.0, 13.0])
+        assert np.array_equal(uda.data, [0, 1, 2, 3])
+
     def test_unary_op(self):
         alltrue = self.uda.astype(bool)
         allfalse = alltrue.copy()

--- a/xugrid/__init__.py
+++ b/xugrid/__init__.py
@@ -1,5 +1,3 @@
-from importlib.metadata import version as _version
-
 from xugrid import data
 from xugrid.core.common import (
     concat,
@@ -30,11 +28,7 @@ from xugrid.ugrid.snapping import snap_to_grid
 from xugrid.ugrid.ugrid1d import Ugrid1d
 from xugrid.ugrid.ugrid2d import Ugrid2d
 
-try:
-    __version__ = _version("xugrid")
-except Exception:
-    # Disable minimum version checks on downstream libraries.
-    __version__ = "9999"
+__version__ = "0.8.1"
 
 __all__ = (
     "data",


### PR DESCRIPTION
@roeldegoede:

I realized the name `rotated` isn't appropriate: supporting multi-dimensional coordinates is more general, e.g. if you have a curvilinear grid (which is approximated by straight edges). I also ran into the trouble of finding out how the coordinates are called. In your example, they are called `xc` and `yc`, but in many other cases they will have different names.

This implementation currently assumes that the last two logical dimensions are always called ("y", "x"), but the multi-dimensional coordinates may be arbitrarily named. They could technically be identified by their attrs (if set), but this seems much simpler.

Taking your example in the issue:

```python
uda = xu.UgridDataArray.from_structured(da)
uda.ugrid.plot()
```

This doesn't specifiy the x and y coordinates, so it works as before: it looks at the x and y dimensions/coordinates. In this case, they are unlabeled, so they are just a range of 0...N.

![image](https://github.com/Deltares/xugrid/assets/13662783/94d4ad1a-d0ae-4770-b00c-2431a5255627)

To succesfully use the multi-dimensional coordinates, specify them explicitly:

```python
uda = xu.UgridDataArray.from_structured(da, x="xc", y="yc")
uda.ugrid.plot()
```

![image](https://github.com/Deltares/xugrid/assets/13662783/f9848d17-3fab-4464-8a52-d281c185c3a3)

This seems to work, if we check with a plot of the original:

```python
da.plot(x="xc", y="yc")
```
![image](https://github.com/Deltares/xugrid/assets/13662783/9ade4257-ddfc-4ad7-b006-3685c5ae5227)

The `.ugrid.plot` seems a bit sharper, maybe due to how to matplotlib treats a PolyCollection (bit of a surprise to me).