### PR TITLE
Fix #206. Deal with review comments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,10 +9,19 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased
 ----------
 
+Fixed
+~~~~~
+
+- :meth:`xugrid.Ugrid2d.equals` and :meth:`xugrid.Ugrid1d.equals` test if
+  dataset is equal instead of testing type.
+- Fixed bug in :func:`xugrid.concat` and :func:`xugrid.merge` where multiple
+  grids were returned if grids did not point to the same object id (i.e.
+  copies).
+
 Added
 ~~~~~
 
-- :meth:`xugrid.Ugrid2.from_structured_multicoord` has been added
+- :meth:`xugrid.Ugrid2d.from_structured_multicoord` has been added
   to generate UGRID topologies from rotated or approximated curvilinear grids.
 - :meth:`xugrid.Ugrid2d.from_structured_intervals1d` has been added to generate
   UGRID topologies from "intervals": the N + 1 vertex coordinates for N faces.

--- a/tests/test_ugrid1d.py
+++ b/tests/test_ugrid1d.py
@@ -453,26 +453,5 @@ def test_equals():
     xr_grid = grid.to_dataset()
     assert not grid.equals(xr_grid)
     grid_copy.attrs["attr"] = "something_else"
-    assert grid.equals(grid_copy)
-
-
-def test_identical():
-    grid = grid1d()
-    grid_copy = grid1d()
-    assert grid.identical(grid)
-    assert grid.identical(grid_copy)
-    xr_grid = grid.to_dataset()
-    assert not grid.identical(xr_grid)
-    grid_copy.attrs["attr"] = "something_else"
-    assert not grid.identical(grid_copy)
-
-
-def test_eq():
-    grid = grid1d()
-    grid_copy = grid1d()
-    assert grid == grid
-    assert grid == grid_copy
-    xr_grid = grid.to_dataset()
-    assert grid != xr_grid
-    grid_copy.attrs["attr"] = "something_else"
-    assert grid != grid_copy
+    # Dataset.identical is called so returns False
+    assert not grid.equals(grid_copy)

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -1363,26 +1363,4 @@ def test_equals():
     xr_grid = grid.to_dataset()
     assert not grid.equals(xr_grid)
     grid_copy.attrs["attr"] = "something_else"
-    assert grid.equals(grid_copy)
-
-
-def test_identical():
-    grid = grid2d()
-    grid_copy = grid2d()
-    assert grid.identical(grid)
-    assert grid.identical(grid_copy)
-    xr_grid = grid.to_dataset()
-    assert not grid.identical(xr_grid)
-    grid_copy.attrs["attr"] = "something_else"
-    assert not grid.identical(grid_copy)
-
-
-def test_eq():
-    grid = grid2d()
-    grid_copy = grid2d()
-    assert grid == grid
-    assert grid == grid_copy
-    xr_grid = grid.to_dataset()
-    assert grid != xr_grid
-    grid_copy.attrs["attr"] = "something_else"
-    assert grid != grid_copy
+    assert not grid.equals(grid_copy)

--- a/xugrid/core/utils.py
+++ b/xugrid/core/utils.py
@@ -59,21 +59,12 @@ class UncachedAccessor:
         return self._accessor(obj)  # type: ignore  # assume it is a valid accessor!
 
 
-def partition(grids: list[UgridType]):
-    parts = []
-    for item in grids:
-        for part in parts:
-            if item.equals(part[0]):
-                part.append(item)
+def unique_grids(grids: list[UgridType]) -> list[UgridType]:
+    uniques: list[UgridType] = []
+    for grid in grids:
+        for unique in uniques:
+            if grid.equals(unique):
                 break
         else:
-            parts.append([item])
-    return parts
-
-
-def unique_grids(grids: list[UgridType]):
-    """
-    Find uniques in list of unhashable elements.
-    Source: https://stackoverflow.com/a/54964373
-    """
-    return [p[0] for p in partition(grids)]
+            uniques.append(grid)
+    return uniques

--- a/xugrid/core/utils.py
+++ b/xugrid/core/utils.py
@@ -63,7 +63,7 @@ def partition(grids: list[UgridType]):
     parts = []
     for item in grids:
         for part in parts:
-            if item == part[0]:
+            if item.equals(part[0]):
                 part.append(item)
                 break
         else:

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -84,14 +84,6 @@ def align(obj, grids, old_indexes):
     return obj, new_grids
 
 
-def to_xr_if_possible(other):
-    # Test if to_dataset method is present
-    if hasattr(other, "to_dataset") and callable(other.to_dataset):
-        return other.to_dataset()
-    else:
-        return other
-
-
 class AbstractUgrid(abc.ABC):
     @abc.abstractproperty
     def topology_dimension():
@@ -280,28 +272,14 @@ class AbstractUgrid(abc.ABC):
         else:
             return self.to_dataset().__repr__()
 
-    def __eq__(self, other) -> bool:
-        return self.identical(other)
-
     def equals(self, other) -> bool:
         if other is self:
             return True
-        elif not isinstance(other, type(self)):
-            return False
-        else:
+        elif isinstance(other, type(self)):
             xr_self = self.to_dataset()
-            other_maybe_xr = to_xr_if_possible(other)
-            return xr_self.equals(other_maybe_xr)
-
-    def identical(self, other) -> bool:
-        if other is self:
-            return True
-        elif not isinstance(other, type(self)):
-            return False
-        else:
-            xr_self = self.to_dataset()
-            other_maybe_xr = to_xr_if_possible(other)
-            return xr_self.identical(other_maybe_xr)
+            xr_other = other.to_dataset()
+            return xr_self.identical(xr_other)
+        return False
 
     def copy(self):
         """Create a deepcopy."""


### PR DESCRIPTION
Fixes: https://github.com/Deltares/xugrid/issues/206, related to: https://github.com/Deltares/xugrid/issues/205

Unfortunately, I accidently pushed my changes to ``main``.
@Huite reviewed the changes via chat. This PR is to deal with these review comments.

PR implements the following:
- ``__eq__`` can be removed, as it is not equivalent to the pandas behavior
- ``.identical`` can be renamed to ``.equals`` and original ``.equals`` can be removed
- If else structure is reordered in ``.equals``, to make it more comprehensible
- ``to_xr_if_possible()`` is removed as it was unnecessary