### PR TITLE
add test to wrap ugriddataset twice (should fail now)

### DIFF
--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -291,6 +291,20 @@ def test_ugrid2d_dataset_roundtrip():
     assert grid2._dataset == ds
 
 
+def test_ugrid2d_dataset_no_mutation():
+    grid = grid2d()
+    ds = grid.to_dataset()
+    ds2 = ds.copy()
+    # Test a non-default fill value
+    face_nodes = ds2["mesh2d_face_nodes"]
+    face_nodes = face_nodes.where(face_nodes != -1, other=-999)
+    face_nodes.attrs["_FillValue"] = -999
+    ds2["mesh2d_face_nodes"] = face_nodes
+    reference = ds2.copy()
+    xugrid.Ugrid2d.from_dataset(ds2)
+    assert ds2.identical(reference)
+
+
 def test_ugrid2d_from_meshkernel():
     # Setup a meshkernel Mesh2d mimick
     class Mesh2d(NamedTuple):

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -294,15 +294,14 @@ def test_ugrid2d_dataset_roundtrip():
 def test_ugrid2d_dataset_no_mutation():
     grid = grid2d()
     ds = grid.to_dataset()
-    ds2 = ds.copy()
     # Test a non-default fill value
-    face_nodes = ds2["mesh2d_face_nodes"]
+    face_nodes = ds["mesh2d_face_nodes"]
     face_nodes = face_nodes.where(face_nodes != -1, other=-999)
     face_nodes.attrs["_FillValue"] = -999
-    ds2["mesh2d_face_nodes"] = face_nodes
-    reference = ds2.copy()
-    xugrid.Ugrid2d.from_dataset(ds2)
-    assert ds2.identical(reference)
+    ds["mesh2d_face_nodes"] = face_nodes
+    reference = ds.copy(deep=True)
+    xugrid.Ugrid2d.from_dataset(ds)
+    assert ds.identical(reference)
 
 
 def test_ugrid2d_from_meshkernel():

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -98,7 +98,7 @@ def test_init_errors():
     with pytest.raises(TypeError, match="obj must be xarray.DataArray"):
         xugrid.UgridDataArray(0, GRID())
     with pytest.raises(TypeError, match="grid must be Ugrid1d or Ugrid2d"):
-        .copy(), 0)
+        xugrid.UgridDataArray(DARRAY(), 0)
 
     with pytest.raises(ValueError, match="At least either obj or grids is required"):
         xugrid.UgridDataset()
@@ -1263,6 +1263,7 @@ def test_laplace_interpolate_1d():
     actual = uda.ugrid.laplace_interpolate(direct_solve=True)
     assert isinstance(actual, xugrid.UgridDataArray)
     assert np.allclose(actual, 1.0)
+
 
 def test_ugriddataset_wrap_twice():
     _ = xugrid.UgridDataset(UGRID_DS)

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -1267,6 +1267,16 @@ def test_laplace_interpolate_1d():
     assert np.allclose(actual, 1.0)
 
 
-def test_ugriddataset_wrap_twice():
-    _ = xugrid.UgridDataset(UGRID_DS())
-    _ = xugrid.UgridDataset(UGRID_DS())
+def test_ugriddataset_wrap_twice(tmp_path):
+    """
+    in issue https://github.com/Deltares/xugrid/issues/208 wrapping a ds
+    twice with UgridDataset gave unexpected behaviour. This tests ensures
+    that future changes will not cause that again.
+    """
+    ds_raw = get_ugrid_fillvaluem999_startindex1_ds()
+    file_nc = tmp_path / "ugrid_fillvaluem999_startindex1.nc"
+    ds_raw.to_netcdf(file_nc)
+    ds = xr.open_dataset(file_nc)
+
+    _ = xugrid.UgridDataset(ds)
+    _ = xugrid.UgridDataset(ds)

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -1266,5 +1266,5 @@ def test_laplace_interpolate_1d():
 
 
 def test_ugriddataset_wrap_twice():
-    _ = xugrid.UgridDataset(UGRID_DS)
-    _ = xugrid.UgridDataset(UGRID_DS)
+    _ = xugrid.UgridDataset(UGRID_DS())
+    _ = xugrid.UgridDataset(UGRID_DS())

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -1270,8 +1270,9 @@ def test_laplace_interpolate_1d():
 def test_ugriddataset_wrap_twice(tmp_path):
     """
     in issue https://github.com/Deltares/xugrid/issues/208 wrapping a ds
-    twice with UgridDataset gave unexpected behaviour. This tests ensures
-    that future changes will not cause that again.
+    twice with UgridDataset resulted in "ValueError: connectivity contains negative values",
+    because the original connectivity array in the xarray dataset was altered.
+    This tests ensures that future changes will not cause this issue again.
     """
     ds_raw = get_ugrid_fillvaluem999_startindex1_ds()
     file_nc = tmp_path / "ugrid_fillvaluem999_startindex1.nc"

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -98,7 +98,7 @@ def test_init_errors():
     with pytest.raises(TypeError, match="obj must be xarray.DataArray"):
         xugrid.UgridDataArray(0, GRID())
     with pytest.raises(TypeError, match="grid must be Ugrid1d or Ugrid2d"):
-        xugrid.UgridDataArray(DARRAY(), 0)
+        .copy(), 0)
 
     with pytest.raises(ValueError, match="At least either obj or grids is required"):
         xugrid.UgridDataset()
@@ -1263,3 +1263,7 @@ def test_laplace_interpolate_1d():
     actual = uda.ugrid.laplace_interpolate(direct_solve=True)
     assert isinstance(actual, xugrid.UgridDataArray)
     assert np.allclose(actual, 1.0)
+
+def test_ugriddataset_wrap_twice():
+    _ = xugrid.UgridDataset(UGRID_DS)
+    _ = xugrid.UgridDataset(UGRID_DS)

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -976,7 +976,7 @@ def test_merge():
     assert len(merged.grids) == 2
 
 
-def get_ugrid_fillvaluem999_startindex1():
+def get_ugrid_fillvaluem999_startindex1_ds():
     """
     Return a minimal dataset with a specific fill value.
 
@@ -1139,12 +1139,14 @@ def get_ugrid_fillvaluem999_startindex1():
     # add dummy nodevar to plot and trigger triangulation procedure
     nodevar = np.ones(shape=(ds2.dims[mesh2d_attrs["node_dimension"]]))
     ds2["mesh2d_nodevar"] = xr.DataArray(nodevar, dims=(mesh2d_attrs["node_dimension"]))
+    return ds2
 
+
+def get_ugrid_fillvaluem999_startindex1_uds():
     # upon loading a dataset from a file, xarray decodes it, so we also do it here
+    ds2 = get_ugrid_fillvaluem999_startindex1_ds()
     ds2_enc = xr.decode_cf(ds2)
-
     uds = xugrid.UgridDataset(ds2_enc)
-
     return uds
 
 
@@ -1156,7 +1158,7 @@ def test_fm_fillvalue_startindex_isel():
     """
 
     # xugrid 0.5.0 warns "RuntimeWarning: invalid value encountered in cast: cast = data.astype(dtype, copy=True)"
-    uds = get_ugrid_fillvaluem999_startindex1()
+    uds = get_ugrid_fillvaluem999_startindex1_uds()
 
     # xugrid 0.6.0 raises "ValueError: Invalid edge_node_connectivity"
     uds.isel({uds.grid.face_dimension: [1]})
@@ -1170,7 +1172,7 @@ def test_fm_facenodeconnectivity_fillvalue():
     """
 
     # xugrid 0.5.0 warns "RuntimeWarning: invalid value encountered in cast: cast = data.astype(dtype, copy=True)"
-    uds = get_ugrid_fillvaluem999_startindex1()
+    uds = get_ugrid_fillvaluem999_startindex1_uds()
 
     # xugrid 0.6.0 has -2 values in the array
     assert (uds.grid.face_node_connectivity != -2).all()

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -389,7 +389,7 @@ class AbstractUgrid(abc.ABC):
         if start_index not in (0, 1):
             raise ValueError(f"start_index should be 0 or 1, received: {start_index}")
 
-        data = da.to_numpy()
+        data = da.to_numpy().copy()
         # If xarray detects a _FillValue, it converts the array to floats and
         # replaces the fill value by NaN, and moves the _FillValue to
         # da.encoding.

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -397,13 +397,14 @@ class AbstractUgrid(abc.ABC):
             is_fill = data == da.attrs["_FillValue"]
         else:
             is_fill = np.isnan(data)
+        # Set the fill_value before casting: otherwise the cast may fail.
         data[is_fill] = fill_value
+        cast = data.astype(dtype, copy=False)
 
-        cast = data.astype(dtype, copy=True)
+        not_fill = ~is_fill
         if start_index:
-            cast -= start_index
-        cast[is_fill] = fill_value
-        if (cast[~is_fill] < 0).any():
+            cast[not_fill] -= start_index
+        if (cast[not_fill] < 0).any():
             raise ValueError("connectivity contains negative values")
         return da.copy(data=cast)
 


### PR DESCRIPTION
@Huite [your suggestion](https://github.com/Deltares/xugrid/issues/208#issuecomment-1921615348) works and I have implemented it in this PR including a testcase that failed before the `.copy()` was added. I guess this is therefore a valid fix. However, I also noticed it works when calling `ds = xr.decode_cf(ds)` upon trying to create a testcase for this situation. This is unexpected, since `ds = xr.open_dataset(file_nc)` also has a `decode_cf=True` as default. Maybe this triggers you to find a solution elsewhere in the code. If not, I think this PR can be merged.