### PR TITLE
Issue #134 merge partitions with inconsistent grids amongst partitions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Fixed
   copies).
 - Fixed bug in :meth:`xugrid.Ugrid1d.merge_partitions`, which caused
   ``ValueError: indexes must be provided for attrs``.
+- :func:`xugrid.merge_partitions` merges partitions with grids not contained in
+  other partitions.
 
 Added
 ~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,8 +19,6 @@ Fixed
   copies).
 - Fixed bug in :meth:`xugrid.Ugrid1d.merge_partitions`, which caused
   ``ValueError: indexes must be provided for attrs``.
-- :func:`xugrid.merge_partitions` now also merges datasets with grids that are
-  only contained in some of the partition datasets.
 
 Added
 ~~~~~
@@ -47,8 +45,8 @@ Changed
 
 - :meth:`xugrid.Ugrid2d.from_structured` now takes ``x`` and ``y`` arguments instead
   of ``x_bounds`` and ``y_bounds`` arguments.
-- :func:`xugrid.merge_partitions` allows merging partitions with different grids
-  per partition.
+- :func:`xugrid.merge_partitions` now also merges datasets with grids that are
+  only contained in some of the partition datasets.
 
 [0.8.1] 2024-01-19
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,8 @@ Changed
 
 - :meth:`xugrid.Ugrid2d.from_structured` now takes ``x`` and ``y`` arguments instead
   of ``x_bounds`` and ``y_bounds`` arguments.
+- :func:`xugrid.merge_partitions` allows merging partitions with different grids
+  per partition.
 
 [0.8.1] 2024-01-19
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,11 @@ Added
   UGRID topologies from "intervals": the (M + 1, N + 1) vertex coordinates for N faces.
 - :meth:`xugrid.UgridDataArrayAccessor.from_structured` now takes ``x`` and ``y``
   arguments to specify which coordinates to use as the UGRID x and y coordinates.
+- :attr:`xugrid.UgridDataset.sizes` as an alternative to :attr:`xugrid.UgridDataset.dimensions`
+- :attr:`xugrid.Ugrid2d.max_face_node_dimension` which returns the dimension
+  name designating nodes per face.
+- :attr:`xugrid.AbstractUgrid.max_connectivity_dimensions` which returns all
+  maximum connectivity dimensions and their corresponding size.
 
 Changed
 ~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,8 +19,8 @@ Fixed
   copies).
 - Fixed bug in :meth:`xugrid.Ugrid1d.merge_partitions`, which caused
   ``ValueError: indexes must be provided for attrs``.
-- :func:`xugrid.merge_partitions` merges partitions with grids not contained in
-  other partitions.
+- :func:`xugrid.merge_partitions` now also merges datasets with grids that are
+  only contained in some of the partition datasets.
 
 Added
 ~~~~~
@@ -36,8 +36,11 @@ Added
 - :attr:`xugrid.UgridDataset.sizes` as an alternative to :attr:`xugrid.UgridDataset.dimensions`
 - :attr:`xugrid.Ugrid2d.max_face_node_dimension` which returns the dimension
   name designating nodes per face.
-- :attr:`xugrid.AbstractUgrid.max_connectivity_dimensions` which returns all
+- :attr:`xugrid.AbstractUgrid.max_connectivity_sizes` which returns all
   maximum connectivity dimensions and their corresponding size.
+- :attr:`xugrid.AbstractUgrid.max_connectivity_dimensions` which returns all
+  maximum connectivity dimensions.
+
 
 Changed
 ~~~~~~~

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -313,3 +313,20 @@ class TestMultiTopology1D2DMergePartitions:
         assert merged["c"] == 0
 
         assert self.dataset_expected.equals(merged)
+
+    def test_merge_partitions_inconsistent_grid_types(self):
+        self.datasets_parts[0] = self.datasets_parts[0].drop_vars("b")
+        b = self.dataset_expected["b"].isel(mesh1d_nEdges=[0, 1, 2])
+        self.dataset_expected = self.dataset_expected.drop_vars(["b", "mesh1d_nEdges"])
+        self.dataset_expected["b"] = b
+        self.dataset_expected["c"] = 1
+
+        merged = pt.merge_partitions(self.datasets_parts)
+        assert isinstance(merged, xu.UgridDataset)
+        assert len(merged.ugrid.grids) == 2
+        # In case of non-UGRID data, it should default to the first partition in
+        # the last grid:
+        assert merged["c"] == 1
+
+        assert self.dataset_expected.equals(merged)
+

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -139,12 +139,12 @@ class TestDatasetPartition:
 
         grid1 = partitions[1].ugrid.grid
         partitions[1]["extra"] = (grid1.face_dimension, np.ones(grid1.n_face))
-        with pytest.raises(ValueError, match="These variables are present"):
+        with pytest.raises(ValueError, match="'extra' does not occur not in all partitions with 'mesh2d'"):
             pt.merge_partitions(partitions)
 
         partitions = self.uds.ugrid.partition(n_part=2)
         partitions[1]["face_z"] = partitions[1]["face_z"].expand_dims("layer", axis=0)
-        with pytest.raises(ValueError, match="Dimensions for face_z do not match"):
+        with pytest.raises(ValueError, match="Dimensions for 'face_z' do not match"):
             pt.merge_partitions(partitions)
 
         uds = self.uds.copy()
@@ -188,10 +188,29 @@ class TestMultiTopology2DMergePartitions:
         merged = pt.merge_partitions(self.datasets)
         assert isinstance(merged, xu.UgridDataset)
         assert len(merged.ugrid.grids) == 2
-        # In case of non-UGRID data, it should default to the first partition:
-        assert merged["c"] == 0
+        # In case of non-UGRID data, it should default to the last partition:
+        assert merged["c"] == 1
+
+        assert len(merged["first_nFaces"]) == 6
+        assert len(merged["second_nFaces"]) == 20
+
+    def test_merge_partitions__unique_grid_per_partition(self):
+        pa = self.datasets[0][["a"]]
+        pb = self.datasets[1][["b"]]
+        merged = pt.merge_partitions([pa, pb])
+
+        assert isinstance(merged, xu.UgridDataset)
+        assert len(merged.ugrid.grids) == 2
+
+        assert len(merged["first_nFaces"]) == 3
+        assert len(merged["second_nFaces"]) == 10
 
     def test_merge_partitions__errors(self):
+        pa = self.datasets[0][["a"]] * xr.DataArray([1.0, 1.0], dims=("error_dim",))
+        pb = self.datasets[1][["a"]]
+        with pytest.raises(ValueError, match="Dimensions for 'a' do not match across partitions: "):
+            pt.merge_partitions([pa, pb])
+
         grid_a = self.datasets[1].ugrid.grids[0].copy()
         grid_c = self.datasets[1].ugrid.grids[1].copy()
         grid_c._attrs["face_dimension"] = "abcdef"
@@ -243,7 +262,7 @@ class TestMergeDataset1D:
 
         ds_expected = xu.UgridDataset(grids=[grid])
         ds_expected["a"] = ((grid.edge_dimension), np.concatenate(values_parts))
-        ds_expected["c"] = 0
+        ds_expected["c"] = 1
         # Assign coordinates also added during merge_partitions
         coords = {grid.edge_dimension: np.arange(grid.n_edge)}
         ds_expected = ds_expected.assign_coords(**coords)
@@ -255,9 +274,9 @@ class TestMergeDataset1D:
         merged = pt.merge_partitions(self.datasets_partitioned)
         assert isinstance(merged, xu.UgridDataset)
         assert len(merged.ugrid.grids) == 1
-        # In case of non-UGRID data, it should default to the first partition of
+        # In case of non-UGRID data, it should default to the last partition of
         # the grid that's checked last.
-        assert merged["c"] == 0
+        assert merged["c"] == 1
 
         assert self.dataset_expected.ugrid.grid.equals(merged.ugrid.grid)
         assert self.dataset_expected["a"].equals(merged["a"])
@@ -296,7 +315,7 @@ class TestMultiTopology1D2DMergePartitions:
         ds_expected = xu.UgridDataset(grids=[grid_a, grid_b])
         ds_expected["a"] = ((grid_a.face_dimension), np.concatenate(values_parts_a))
         ds_expected["b"] = ((grid_b.edge_dimension), np.concatenate(values_parts_b))
-        ds_expected["c"] = 0
+        ds_expected["c"] = 1
         # Assign coordinates also added during merge_partitions
         coords = {
             grid_a.face_dimension: np.concatenate(values_parts_a),
@@ -311,9 +330,9 @@ class TestMultiTopology1D2DMergePartitions:
         merged = pt.merge_partitions(self.datasets_parts)
         assert isinstance(merged, xu.UgridDataset)
         assert len(merged.ugrid.grids) == 2
-        # In case of non-UGRID data, it should default to the first partition of
+        # In case of non-UGRID data, it should default to the last partition of
         # the grid that's checked last.
-        assert merged["c"] == 0
+        assert merged["c"] == 1
 
         assert self.dataset_expected.equals(merged)
 
@@ -329,14 +348,9 @@ class TestMultiTopology1D2DMergePartitions:
         merged = pt.merge_partitions(self.datasets_parts)
         assert isinstance(merged, xu.UgridDataset)
         assert len(merged.ugrid.grids) == 2
-        # In case of non-UGRID data, it should default to the first partition of
+        # In case of non-UGRID data, it should default to the last partition of
         # the grid that's checked last.
         assert merged["c"] == 1
 
         assert self.dataset_expected.equals(merged)
 
-    def test_merge_partitions__errors(self):
-        pa = self.datasets_parts[0][["a"]] * xr.DataArray([1.0, 1.0], dims=("error_dim",))
-        pb = self.datasets_parts[1][["a"]]
-        with pytest.raises(ValueError, match="Dimensions for 'a' do not match across partitions: "):
-            pt.merge_partitions([pa, pb])

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -139,7 +139,10 @@ class TestDatasetPartition:
 
         grid1 = partitions[1].ugrid.grid
         partitions[1]["extra"] = (grid1.face_dimension, np.ones(grid1.n_face))
-        with pytest.raises(ValueError, match="'extra' does not occur not in all partitions with 'mesh2d'"):
+        with pytest.raises(
+            ValueError,
+            match="'extra' does not occur not in all partitions with 'mesh2d'",
+        ):
             pt.merge_partitions(partitions)
 
         partitions = self.uds.ugrid.partition(n_part=2)
@@ -208,7 +211,9 @@ class TestMultiTopology2DMergePartitions:
     def test_merge_partitions__errors(self):
         pa = self.datasets[0][["a"]] * xr.DataArray([1.0, 1.0], dims=("error_dim",))
         pb = self.datasets[1][["a"]]
-        with pytest.raises(ValueError, match="Dimensions for 'a' do not match across partitions: "):
+        with pytest.raises(
+            ValueError, match="Dimensions for 'a' do not match across partitions: "
+        ):
             pt.merge_partitions([pa, pb])
 
         grid_a = self.datasets[1].ugrid.grids[0].copy()
@@ -353,4 +358,3 @@ class TestMultiTopology1D2DMergePartitions:
         assert merged["c"] == 1
 
         assert self.dataset_expected.equals(merged)
-

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -141,7 +141,7 @@ class TestDatasetPartition:
         partitions[1]["extra"] = (grid1.face_dimension, np.ones(grid1.n_face))
         with pytest.raises(
             ValueError,
-            match="'extra' does not occur not in all partitions with 'mesh2d'",
+            match="Missing variables: {'extra'} in partition",
         ):
             pt.merge_partitions(partitions)
 

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -192,11 +192,6 @@ class TestMultiTopology2DMergePartitions:
         assert merged["c"] == 0
 
     def test_merge_partitions__errors(self):
-        pa = self.datasets[0][["a"]]
-        pb = self.datasets[1][["b"]]
-        with pytest.raises(ValueError, match="Expected 2 UGRID topologies"):
-            pt.merge_partitions([pa, pb])
-
         grid_a = self.datasets[1].ugrid.grids[0].copy()
         grid_c = self.datasets[1].ugrid.grids[1].copy()
         grid_c._attrs["face_dimension"] = "abcdef"
@@ -322,8 +317,10 @@ class TestMultiTopology1D2DMergePartitions:
 
         assert self.dataset_expected.equals(merged)
 
-    def test_merge_partitions_inconsistent_grid_types(self):
-        self.datasets_parts[0] = self.datasets_parts[0].drop_vars(["b", "mesh1d_nEdges"])
+    def test_merge_partitions__inconsistent_grid_types(self):
+        self.datasets_parts[0] = self.datasets_parts[0].drop_vars(
+            ["b", "mesh1d_nEdges"]
+        )
         b = self.dataset_expected["b"].isel(mesh1d_nEdges=[0, 1, 2])
         self.dataset_expected = self.dataset_expected.drop_vars(["b", "mesh1d_nEdges"])
         self.dataset_expected["b"] = b
@@ -338,3 +335,8 @@ class TestMultiTopology1D2DMergePartitions:
 
         assert self.dataset_expected.equals(merged)
 
+    def test_merge_partitions__errors(self):
+        pa = self.datasets_parts[0][["a"]] * xr.DataArray([1.0, 1.0], dims=("error_dim",))
+        pb = self.datasets_parts[1][["a"]]
+        with pytest.raises(ValueError, match="Dimensions for 'a' do not match across partitions: "):
+            pt.merge_partitions([pa, pb])

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -228,7 +228,7 @@ def validate_vars_in_all_data_objects(
     return None
 
 
-def separate_variables(objects_by_gridname, ugrid_dims):
+def separate_variables(objects_by_gridname: defaultdict[str, xr.Dataset], ugrid_dims: set[str]):
     """Separate into UGRID variables grouped by dimension, and other variables."""
     validate_partition_objects(objects_by_gridname)
 
@@ -348,7 +348,7 @@ def merge_partitions(partitions):
         merged_grid, indexes = grid.merge_partitions(grids)
         merged_grids.append(merged_grid)
 
-        # Add all other vars to dataset
+        # Add other vars, unassociated with UGRID dimensions, to dataset.
         for obj in data_objects:
             other_vars_obj = set(other_vars).intersection(set(obj.data_vars))
             merged.update(obj[other_vars_obj])

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -268,7 +268,7 @@ def separate_variables(objects_by_gridname, ugrid_dims):
 
 
 def maybe_pad_connectivity_dims_to_max(selection, merged_grid):
-    nmax_dict = merged_grid.max_connectivity_dimensions
+    nmax_dict = merged_grid.max_connectivity_sizes
     nmax_dict = {
         key: value for key, value in nmax_dict.items() if key in selection[0].dims
     }

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -359,15 +359,9 @@ def merge_partitions(partitions):
             if len(vars) == 0:
                 continue
             validate_vars_in_all_data_objects(vars, data_objects, gridname)
-            first_var = next(iter(vars))
-            objects_indexes_to_select = [
-                (obj[vars], index)
-                for obj, index in zip(data_objects, dim_indexes)
-                if first_var in obj
-            ]
             selection = [
                 obj[vars].isel({dim: index}, missing_dims="ignore")
-                for obj, index in objects_indexes_to_select
+                for obj, index in zip(data_objects, dim_indexes)
             ]
             selection_padded = maybe_pad_connectivity_dims_to_max(
                 selection, merged_grid

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -207,9 +207,12 @@ def validate_partition_objects(objects_by_gridname):
                     f"{vardims_ls[0]} versus {vardims_ls[1]}"
                 )
 
+
 def validate_vars_in_all_data_objects(vars, data_objects, gridname):
     for var in vars:
-        var_in_objects = [True if var in obj.variables else False for obj in data_objects]
+        var_in_objects = [
+            True if var in obj.variables else False for obj in data_objects
+        ]
         if not all(var_in_objects):
             raise ValueError(
                 f"'{var}' does not occur not in all partitions with '{gridname}'"

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -262,13 +262,20 @@ def separate_variables(objects_by_gridname, ugrid_dims):
 
 def maybe_pad_connectivity_dims_to_max(selection, merged_grid):
     nmax_dict = merged_grid.max_connectivity_dimensions
-    nmax_dict = {key: value for key, value in nmax_dict.items() if key in selection[0].dims}
+    nmax_dict = {
+        key: value for key, value in nmax_dict.items() if key in selection[0].dims
+    }
     if not nmax_dict:
         return selection
-    
-    pad_width_ls = [{dim: (0, nmax - obj.sizes[dim]) for dim, nmax in nmax_dict.items()} for obj in selection]
 
-    return [obj.pad(pad_width = pad_width) for obj, pad_width in zip(selection, pad_width_ls)]
+    pad_width_ls = [
+        {dim: (0, nmax - obj.sizes[dim]) for dim, nmax in nmax_dict.items()}
+        for obj in selection
+    ]
+
+    return [
+        obj.pad(pad_width=pad_width) for obj, pad_width in zip(selection, pad_width_ls)
+    ]
 
 
 def merge_partitions(partitions):
@@ -306,15 +313,21 @@ def merge_partitions(partitions):
     grids_by_name = group_grids_by_name(partitions)
     # TODO: make sure 1D variables also in vars_by_dim
     data_objects_by_name = group_data_objects_by_gridname(partitions)
-    vars_by_dim, other_vars_by_name = separate_variables(data_objects_by_name, ugrid_dims)
+    vars_by_dim, other_vars_by_name = separate_variables(
+        data_objects_by_name, ugrid_dims
+    )
 
     # First, take identical non-UGRID variables from the first partition:
-    merged = xr.Dataset() # data_objects[0][other_vars]
+    merged = xr.Dataset()  # data_objects[0][other_vars]
 
     # Merge the UGRID topologies into one, and find the indexes to index into
     # the data to avoid duplicates.
     merged_grids = []
-    for grids, data_objects, other_vars in zip(grids_by_name.values(), data_objects_by_name.values(), other_vars_by_name.values()):
+    for grids, data_objects, other_vars in zip(
+        grids_by_name.values(),
+        data_objects_by_name.values(),
+        other_vars_by_name.values(),
+    ):
         # First, merge the grid topology.
         merged.update(data_objects[0][other_vars])
         grid = grids[0]
@@ -329,7 +342,9 @@ def merge_partitions(partitions):
                 obj[vars].isel({dim: index}, missing_dims="ignore")
                 for obj, index in zip(data_objects, dim_indexes)
             ]
-            selection_padded = maybe_pad_connectivity_dims_to_max(selection, merged_grid)
+            selection_padded = maybe_pad_connectivity_dims_to_max(
+                selection, merged_grid
+            )
 
             merged_selection = xr.concat(selection_padded, dim=dim)
             merged.update(merged_selection)

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -147,7 +147,7 @@ def merge_edges(grids, node_inverse):
 
 def validate_partition_topology(grouped, n_partition: int):
     n = n_partition
-    if not all(len(v) == n for v in grouped.values()):
+    if False:
         raise ValueError(
             f"Expected {n} UGRID topologies for {n} partitions, received: " f"{grouped}"
         )
@@ -182,6 +182,7 @@ def group_grids_by_name(partitions):
 
 def validate_partition_objects(data_objects):
     # Check presence of variables.
+    # TODO: Groupby gridtype, then test if variables present all grids per type.
     allvars = list({tuple(sorted(ds.data_vars)) for ds in data_objects})
     if len(allvars) > 1:
         raise ValueError(
@@ -200,7 +201,7 @@ def validate_partition_objects(data_objects):
 
 def separate_variables(data_objects, ugrid_dims):
     """Separate into UGRID variables grouped by dimension, and other variables."""
-    validate_partition_objects(data_objects)
+    # validate_partition_objects(data_objects)
 
     def assert_single_dim(intersection):
         if len(intersection) > 1:
@@ -216,6 +217,7 @@ def separate_variables(data_objects, ugrid_dims):
         return all(element == first for element in iterator)
 
     # Group variables by UGRID dimension.
+    #TODO: Take first grid per mesh type
     first = data_objects[0]
     variables = first.variables
     vardims = {var: tuple(first[var].dims) for var in variables}
@@ -280,6 +282,7 @@ def merge_partitions(partitions):
     grids = [grid for p in partitions for grid in p.grids]
     ugrid_dims = {dim for grid in grids for dim in grid.dimensions}
     grids_by_name = group_grids_by_name(partitions)
+    # TODO: make sure 1D variables also in vars_by_dim
     vars_by_dim, other_vars = separate_variables(data_objects, ugrid_dims)
 
     # First, take identical non-UGRID variables from the first partition:
@@ -291,6 +294,7 @@ def merge_partitions(partitions):
     for grids in grids_by_name.values():
         # First, merge the grid topology.
         grid = grids[0]
+        # TODO: shortcut for length 1 merge_partitions
         merged_grid, indexes = grid.merge_partitions(grids)
         merged_grids.append(merged_grid)
 

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -271,7 +271,7 @@ def merge_data_along_dim(
     indexes: list[np.array],
     merged_grid: UgridType,
 ) -> xr.Dataset:
-    """ "
+    """
     Select variables from the data objects.
     Pad connectivity dims if needed.
     Concatenate along dim.

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -214,8 +214,9 @@ def validate_partition_objects(
     return None
 
 
-
-def separate_variables(objects_by_gridname: defaultdict[str, xr.Dataset], ugrid_dims: set[str]):
+def separate_variables(
+    objects_by_gridname: defaultdict[str, xr.Dataset], ugrid_dims: set[str]
+):
     """Separate into UGRID variables grouped by dimension, and other variables."""
     validate_partition_objects(objects_by_gridname)
 
@@ -270,7 +271,7 @@ def merge_data_along_dim(
     indexes: list[np.array],
     merged_grid: UgridType,
 ) -> xr.Dataset:
-    """"
+    """ "
     Select variables from the data objects.
     Pad connectivity dims if needed.
     Concatenate along dim.
@@ -286,7 +287,7 @@ def merge_data_along_dim(
             raise ValueError(f"Missing variables: {missing_vars} in partition {obj}")
 
         selection = obj[vars].isel({merge_dim: index}, missing_dims="ignore")
-        
+
         # Pad the ugrid connectivity dims (e.g. n_max_face_node_connectivity) if
         # needed.
         present_dims = ugrid_connectivity_dims.intersection(selection.dims)
@@ -367,7 +368,9 @@ def merge_partitions(partitions):
             vars = vars_by_dim[dim]
             if len(vars) == 0:
                 continue
-            merged_selection = merge_data_along_dim(data_objects, vars, dim, dim_indexes, merged_grid)
+            merged_selection = merge_data_along_dim(
+                data_objects, vars, dim, dim_indexes, merged_grid
+            )
             merged.update(merged_selection)
 
     return UgridDataset(merged, merged_grids)

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -175,7 +175,9 @@ def group_grids_by_name(partitions: list[UgridDataset]) -> defaultdict[str, Ugri
     return grouped
 
 
-def group_data_objects_by_gridname(partitions: list[UgridDataset]) -> defaultdict[str, xr.Dataset]:
+def group_data_objects_by_gridname(
+    partitions: list[UgridDataset]
+) -> defaultdict[str, xr.Dataset]:
     # Convert to dataset for convenience
     data_objects = [partition.obj for partition in partitions]
     data_objects = [
@@ -191,7 +193,9 @@ def group_data_objects_by_gridname(partitions: list[UgridDataset]) -> defaultdic
     return grouped
 
 
-def validate_partition_objects(objects_by_gridname: defaultdict[str, xr.Dataset]) -> None:
+def validate_partition_objects(
+    objects_by_gridname: defaultdict[str, xr.Dataset]
+) -> None:
     for data_objects in objects_by_gridname.values():
         allvars = list({tuple(sorted(ds.data_vars)) for ds in data_objects})
         unique_vars = set(chain(*allvars))
@@ -210,7 +214,9 @@ def validate_partition_objects(objects_by_gridname: defaultdict[str, xr.Dataset]
     return None
 
 
-def validate_vars_in_all_data_objects(vars: list[str], data_objects: list[xr.Dataset], gridname: str):
+def validate_vars_in_all_data_objects(
+    vars: list[str], data_objects: list[xr.Dataset], gridname: str
+):
     for var in vars:
         var_in_objects = [
             True if var in obj.variables else False for obj in data_objects

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -630,7 +630,7 @@ class Ugrid1d(AbstractUgrid):
         )
 
     @staticmethod
-    def merge_partitions(grids: Sequence["Ugrid1d"]) -> "Ugrid1d":
+    def merge_partitions(grids: Sequence["Ugrid1d"]) -> tuple["Ugrid1d", dict[str, np.array]]:
         """
         Merge grid partitions into a single whole.
 

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -630,7 +630,9 @@ class Ugrid1d(AbstractUgrid):
         )
 
     @staticmethod
-    def merge_partitions(grids: Sequence["Ugrid1d"]) -> tuple["Ugrid1d", dict[str, np.array]]:
+    def merge_partitions(
+        grids: Sequence["Ugrid1d"]
+    ) -> tuple["Ugrid1d", dict[str, np.array]]:
         """
         Merge grid partitions into a single whole.
 

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -422,10 +422,14 @@ class Ugrid2d(AbstractUgrid):
         return self._attrs["max_face_nodes_dimension"]
 
     @property
-    def max_connectivity_dimensions(self):
+    def max_connectivity_sizes(self) -> dict[str, int]:
         return {
             self.max_face_node_dimension: self.n_max_node_per_face,
         }
+
+    @property
+    def max_connectivity_dimensions(self) -> tuple[str]:
+        return (self.max_face_node_dimension,)
 
     @property
     def topology_dimension(self):

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -418,6 +418,16 @@ class Ugrid2d(AbstractUgrid):
         }
 
     @property
+    def max_face_node_dimension(self):
+        return self._attrs["max_face_nodes_dimension"]
+
+    @property
+    def max_connectivity_dimensions(self):
+        return {
+            self.max_face_node_dimension: self.n_max_node_per_face,
+        }
+
+    @property
     def topology_dimension(self):
         """Highest dimensionality of the geometric elements: 2"""
         return 2

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1505,7 +1505,7 @@ class Ugrid2d(AbstractUgrid):
         return [self.topology_subset(index) for index in indices]
 
     @staticmethod
-    def merge_partitions(grids: Sequence["Ugrid2d"]) -> "Ugrid2d":
+    def merge_partitions(grids: Sequence["Ugrid2d"]) -> tuple["Ugrid2d", dict[str, np.array]]:
         """
         Merge grid partitions into a single whole.
 

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -418,7 +418,7 @@ class Ugrid2d(AbstractUgrid):
         }
 
     @property
-    def max_face_node_dimension(self):
+    def max_face_node_dimension(self) -> str:
         return self._attrs["max_face_nodes_dimension"]
 
     @property

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1505,7 +1505,9 @@ class Ugrid2d(AbstractUgrid):
         return [self.topology_subset(index) for index in indices]
 
     @staticmethod
-    def merge_partitions(grids: Sequence["Ugrid2d"]) -> tuple["Ugrid2d", dict[str, np.array]]:
+    def merge_partitions(
+        grids: Sequence["Ugrid2d"]
+    ) -> tuple["Ugrid2d", dict[str, np.array]]:
         """
         Merge grid partitions into a single whole.
 

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -300,7 +300,7 @@ class AbstractUgrid(abc.ABC):
         return self._attrs["edge_dimension"]
 
     @property
-    def max_connectivity_dimensions(self) -> tuple:
+    def max_connectivity_dimensions(self) -> tuple[str]:
         return ()
 
     @property
@@ -308,7 +308,7 @@ class AbstractUgrid(abc.ABC):
         return {}
 
     @property
-    def sizes(self):
+    def sizes(self) -> dict[str, int]:
         return self.dimensions
 
     @property

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -300,6 +300,14 @@ class AbstractUgrid(abc.ABC):
         return self._attrs["edge_dimension"]
 
     @property
+    def max_connectivity_dimensions(self):
+        return {}
+
+    @property
+    def sizes(self):
+        return self.dimensions
+
+    @property
     def node_coordinates(self) -> FloatArray:
         """Coordinates (x, y) of the nodes (vertices)"""
         return np.column_stack([self.node_x, self.node_y])

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -300,7 +300,11 @@ class AbstractUgrid(abc.ABC):
         return self._attrs["edge_dimension"]
 
     @property
-    def max_connectivity_dimensions(self):
+    def max_connectivity_dimensions(self) -> tuple:
+        return ()
+
+    @property
+    def max_connectivity_sizes(self) -> dict[str, int]:
         return {}
 
     @property


### PR DESCRIPTION
Fix #134 and #86,

Add support for merging partitions with different grids in each partition, for example 1D grid in one partition and 2D grids in each. Quite some refactoring was required:

* groups grids, data_objects, and other_vars by gridname
* all partitions with a certain grid should have the same variables, this is validated
* connectivity dims are padded to maximum size if not consistent
* add property to AbstractUgrid to get connectivity dimension names