### PR TITLE
fix path deprecation warning

### DIFF
--- a/xugrid/data/sample_data.py
+++ b/xugrid/data/sample_data.py
@@ -13,7 +13,7 @@ REGISTRY = pooch.create(
     version_dev="main",
     env="XUGRID_DATA_DIR",
 )
-REGISTRY.load_registry(importlib.resources.files("xugrid.data")/ "registry.txt")
+REGISTRY.load_registry(importlib.resources.files("xugrid.data") / "registry.txt")
 
 
 def xoxo():

--- a/xugrid/data/sample_data.py
+++ b/xugrid/data/sample_data.py
@@ -13,8 +13,7 @@ REGISTRY = pooch.create(
     version_dev="main",
     env="XUGRID_DATA_DIR",
 )
-with importlib.resources.files("xugrid.data") as path:
-    REGISTRY.load_registry(path / "registry.txt")
+REGISTRY.load_registry(importlib.resources.files("xugrid.data")/ "registry.txt")
 
 
 def xoxo():


### PR DESCRIPTION
Use of path as a context manager is deprecated and leads to a warning. In this case, just assigning the variable directly, solves the problem. 