### PR TITLE
Let ruff fix more issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ ignore = [
     "PD003",
     "PD004",
 ]
-fixable = ["I"]
 ignore-init-module-imports = true
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
This will now use the default of fixing everything it can safely fix:

```toml
fixable = ["ALL"]
```

Rather than only the isort rules: https://docs.astral.sh/ruff/rules/#isort-i

Not sure why it was set to "I".