### PR TITLE
Do not drop out-of-bounds point silently in sel_points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,10 +33,11 @@ Changed
 - :meth:`xugrid.Ugrid2d.sel_points`,
   :meth:`xugrid.UgridDataArrayAccessor.sel_points` and
   :meth:`xugrid.UgridDatasetAccessor.sel_points` now take an ``out_of_bounds``
-  keyword to determine what to with points that do not fall inside of any grid
-  feature. Previously, the method silently dropped these points. The method now
-  returns NaN for out-of-bounds points and gives a warning by default. To enable
-  the old behavior, specify ``out_of_bounds="drop"``.
+  and ``fill_value`` argument to determine what to with points that do not fall
+  inside of any grid feature. Previously, the method silently dropped these
+  points. The method now takes a ``fill_value`` argument to assign to
+  out-of-bounds points. It gives a warning return uses ``fill_value=np.nan`` by
+  default. To enable the old behavior, set ``out_of_bounds="drop"``.
 
 [0.11.0] 2024-08-05
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,13 @@ Changed
 
 - Custom reduction functions provide to the overlap regridders no longer require
   an ``indices`` argument.
+- :meth:`xugrid.Ugrid2d.sel_points`,
+  :meth:`xugrid.UgridDataArrayAccessor.sel_points` and
+  :meth:`xugrid.UgridDatasetAccessor.sel_points` now take an ``out_of_bounds``
+  keyword to determine what to with points that do not fall inside of any grid
+  feature. Previously, the method silently dropped these points. The method now
+  returns NaN for out-of-bounds points and gives a warning by default. To enable
+  the old behavior, specify ``out_of_bounds="drop"``.
 
 [0.11.0] 2024-08-05
 -------------------

--- a/tests/test_ugrid1d.py
+++ b/tests/test_ugrid1d.py
@@ -342,6 +342,20 @@ def test_sel():
     assert np.array_equal(new_obj.values, [0])
 
 
+def test_sel_points():
+    grid = grid1d()
+    obj = xr.DataArray(
+        data=[0, 1],
+        dims=[grid.edge_dimension],
+    )
+    # For now, this function does nothing so it'll work for multi-topology
+    # UgridDatasets.
+    actual = grid.sel_points(
+        obj=obj, x=None, y=None, out_of_bounds=None, fill_value=None
+    )
+    assert actual.identical(obj)
+
+
 def test_topology_subset():
     grid = grid1d()
     edge_indices = np.array([1])

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -713,6 +713,11 @@ class TestUgrid2dSelection:
         actual = self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="ignore")
         assert np.allclose(actual, [np.nan, 0, np.nan, 3, np.nan], equal_nan=True)
 
+        actual = self.grid.sel_points(
+            obj=self.obj, x=x, y=y, out_of_bounds="ignore", fill_value=-1
+        )
+        assert np.allclose(actual, [-1, 0, -1, 3, -1])
+
     def test_validate_indexer(self):
         with pytest.raises(ValueError, match="slice stop should be larger than"):
             self.grid._validate_indexer(slice(2, 0))

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -670,6 +670,8 @@ class TestUgrid2dSelection:
         x = [0.5, 1.5]
         y = [0.5, 1.25]
 
+        with pytest.raises(ValueError, match="out_of_bounds must be one of"):
+            self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="nothing")
         with pytest.raises(ValueError, match="shape of x does not match shape of y"):
             self.grid.sel_points(obj=self.obj, x=[0.5, 1.5], y=[0.5])
         with pytest.raises(ValueError, match="x and y must be 1d"):
@@ -693,8 +695,23 @@ class TestUgrid2dSelection:
     def test_sel_points_out_of_bounds(self):
         x = [-10.0, 0.5, -20.0, 1.5, -30.0]
         y = [-10.0, 0.5, -20.0, 1.25, -30.0]
-        actual = self.grid.sel_points(obj=self.obj, x=x, y=y)
+
+        with pytest.raises(
+            ValueError, match="Not all points are located inside of the grid"
+        ):
+            self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="raise")
+
+        actual = self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="drop")
         assert np.array_equal(actual[f"{NAME}_index"], [1, 3])
+
+        with pytest.warns(
+            UserWarning, match="Not all points are located inside of the grid"
+        ):
+            actual = self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="warn")
+            assert np.allclose(actual, [np.nan, 0, np.nan, 3, np.nan], equal_nan=True)
+
+        actual = self.grid.sel_points(obj=self.obj, x=x, y=y, out_of_bounds="ignore")
+        assert np.allclose(actual, [np.nan, 0, np.nan, 3, np.nan], equal_nan=True)
 
     def test_validate_indexer(self):
         with pytest.raises(ValueError, match="slice stop should be larger than"):

--- a/xugrid/core/accessorbase.py
+++ b/xugrid/core/accessorbase.py
@@ -38,7 +38,7 @@ class AbstractUgridAccessor(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def sel_points(self):
+    def sel_points(self, x, y, out_of_bounds, fill_value):
         pass
 
     @abc.abstractmethod

--- a/xugrid/core/dataarray_accessor.py
+++ b/xugrid/core/dataarray_accessor.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Sequence, Tuple, Union
 
+import numpy as np
 import scipy.sparse
 import xarray as xr
 
@@ -175,7 +176,7 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         else:
             return result
 
-    def sel_points(self, x, y, out_of_bounds="warn"):
+    def sel_points(self, x, y, out_of_bounds="warn", fill_value=np.nan):
         """
         Select points in the unstructured grid.
 
@@ -186,21 +187,23 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         ----------
         x: ndarray of floats with shape ``(n_points,)``
         y: ndarray of floats with shape ``(n_points,)``
-
-        out_of_bounds: str, default "warn"
+        out_of_bounds: str, default: "warn"
             What to do when points are located outside of any feature:
 
             * raise: raise a ValueError.
-            * ignore: return NaN for the out of bounds points.
+            * ignore: return ``fill_value`` for the out of bounds points.
             * warn: give a warning and return NaN for the out of bounds points.
             * drop: drop the out of bounds points. They may be identified
               via the ``index`` coordinate of the returned selection.
+        fill_value: scalar, DataArray, Dataset, or callable, optional, default: np.nan
+            Value to assign to out-of-bounds points if out_of_bounds is warn
+            or ignore. Forwarded to xarray's ``.where()`` method.
 
         Returns
         -------
         points: Union[xr.DataArray, xr.Dataset]
         """
-        return self.grid.sel_points(self.obj, x, y, out_of_bounds)
+        return self.grid.sel_points(self.obj, x, y, out_of_bounds, fill_value)
 
     def rasterize(self, resolution: float) -> xr.DataArray:
         """

--- a/xugrid/core/dataarray_accessor.py
+++ b/xugrid/core/dataarray_accessor.py
@@ -175,7 +175,7 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         else:
             return result
 
-    def sel_points(self, x, y):
+    def sel_points(self, x, y, out_of_bounds="warn"):
         """
         Select points in the unstructured grid.
 
@@ -187,11 +187,20 @@ class UgridDataArrayAccessor(AbstractUgridAccessor):
         x: ndarray of floats with shape ``(n_points,)``
         y: ndarray of floats with shape ``(n_points,)``
 
+        out_of_bounds: str, default "warn"
+            What to do when points are located outside of any feature:
+
+            * raise: raise a ValueError.
+            * ignore: return NaN for the out of bounds points.
+            * warn: give a warning and return NaN for the out of bounds points.
+            * drop: drop the out of bounds points. They may be identified
+              via the ``index`` coordinate of the returned selection.
+
         Returns
         -------
         points: Union[xr.DataArray, xr.Dataset]
         """
-        return self.grid.sel_points(self.obj, x, y)
+        return self.grid.sel_points(self.obj, x, y, out_of_bounds)
 
     def rasterize(self, resolution: float) -> xr.DataArray:
         """

--- a/xugrid/core/dataset_accessor.py
+++ b/xugrid/core/dataset_accessor.py
@@ -229,7 +229,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         else:
             return result
 
-    def sel_points(self, x, y):
+    def sel_points(self, x, y, out_of_bounds="warn"):
         """
         Select points in the unstructured grid.
 
@@ -241,6 +241,15 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         x: ndarray of floats with shape ``(n_points,)``
         y: ndarray of floats with shape ``(n_points,)``
 
+        out_of_bounds: str, default ``"warn"``
+            What to do when points are located outside of any feature:
+
+            * raise: raise a ValueError.
+            * ignore: return NaN for the out of bounds points.
+            * warn: give a warning and return NaN for the out of bounds points.
+            * drop: drop the out of bounds points. They may be identified
+              via the ``index`` coordinate of the returned selection.
+
         Returns
         -------
         points: Union[xr.DataArray, xr.Dataset]
@@ -248,7 +257,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         """
         result = self.obj
         for grid in self.grids:
-            result = grid.sel_points(result, x, y)
+            result = grid.sel_points(result, x, y, out_of_bounds)
         return result
 
     def rasterize(self, resolution: float) -> xr.Dataset:

--- a/xugrid/core/dataset_accessor.py
+++ b/xugrid/core/dataset_accessor.py
@@ -229,7 +229,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         else:
             return result
 
-    def sel_points(self, x, y, out_of_bounds="warn"):
+    def sel_points(self, x, y, out_of_bounds="warn", fill_value=np.nan):
         """
         Select points in the unstructured grid.
 
@@ -240,15 +240,17 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         ----------
         x: ndarray of floats with shape ``(n_points,)``
         y: ndarray of floats with shape ``(n_points,)``
-
         out_of_bounds: str, default ``"warn"``
             What to do when points are located outside of any feature:
 
             * raise: raise a ValueError.
-            * ignore: return NaN for the out of bounds points.
+            * ignore: return ``fill_value`` for the out of bounds points.
             * warn: give a warning and return NaN for the out of bounds points.
             * drop: drop the out of bounds points. They may be identified
               via the ``index`` coordinate of the returned selection.
+        fill_value: scalar, DataArray, Dataset, or callable, optional, default: np.nan
+            Value to assign to out-of-bounds points if out_of_bounds is warn
+            or ignore. Forwarded to xarray's ``.where()`` method.
 
         Returns
         -------
@@ -257,7 +259,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         """
         result = self.obj
         for grid in self.grids:
-            result = grid.sel_points(result, x, y, out_of_bounds)
+            result = grid.sel_points(result, x, y, out_of_bounds, fill_value)
         return result
 
     def rasterize(self, resolution: float) -> xr.Dataset:

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -574,7 +574,7 @@ class Ugrid1d(AbstractUgrid):
     ):
         return self.sel(x=slice(xmin, xmax), y=slice(ymin, ymax))
 
-    def sel_points(obj, x, y):
+    def sel_points(obj, x, y, out_of_bounds):
         return obj
 
     def intersect_line(self, obj, start, stop):

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -574,7 +574,7 @@ class Ugrid1d(AbstractUgrid):
     ):
         return self.sel(x=slice(xmin, xmax), y=slice(ymin, ymax))
 
-    def sel_points(obj, x, y, out_of_bounds):
+    def sel_points(self, obj, x, y, out_of_bounds, fill_value):
         return obj
 
     def intersect_line(self, obj, start, stop):

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1354,9 +1354,6 @@ class Ugrid2d(AbstractUgrid):
             elif out_of_bounds == "drop":
                 index = index[valid]
                 keep = valid
-            else:
-                # This code shouldn't be reachable due to check up top.
-                raise ValueError("invalid out_of_bounds options")
 
         # Create the selection DataArray or Dataset
         coords = {

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1344,14 +1344,12 @@ class Ugrid2d(AbstractUgrid):
         condition = None
         valid = index != -1
         if not valid.all():
+            msg = "Not all points are located inside of the grid."
             if out_of_bounds == "raise":
-                raise ValueError("Not all points are located inside of the grid.")
+                raise ValueError(msg)
             elif out_of_bounds in ("warn", "ignore"):
                 if out_of_bounds == "warn":
-                    warnings.warn(
-                        "Not all points are located inside of the grid. "
-                        "Out of bounds points are marked by NaN."
-                    )
+                    warnings.warn(msg)
                 condition = xr.DataArray(valid, dims=(dim,))
             elif out_of_bounds == "drop":
                 index = index[valid]

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from itertools import chain
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
@@ -1292,24 +1293,38 @@ class Ugrid2d(AbstractUgrid):
         ystop = numeric_bound(y.stop, ymax)
         return self._sel_line(obj, start=(x, ystart), end=(x, ystop))
 
-    def sel_points(self, obj, x: FloatArray, y: FloatArray):
+    def sel_points(self, obj, x: FloatArray, y: FloatArray, out_of_bounds="warn"):
         """
         Select points in the unstructured grid.
 
-        Out-of-bounds points are ignored. They may be identified via the
-        ``index`` coordinate of the returned selection.
 
         Parameters
         ----------
         x: 1d array of floats with shape ``(n_points,)``
         y: 1d array of floats with shape ``(n_points,)``
         obj: xr.DataArray or xr.Dataset
+        out_of_bounds: str, default ``"warn"``
+            What to do when points are located outside of any feature:
+
+            * raise: raise a ValueError.
+            * ignore: return NaN for the out of bounds points.
+            * warn: give a warning and return NaN for the out of bounds points.
+            * drop: drop the out of bounds points. They may be identified
+              via the ``index`` coordinate of the returned selection.
 
         Returns
         -------
         selection: xr.DataArray or xr.Dataset
             The name of the topology is prefixed in the x, y coordinates.
         """
+        options = ("warn", "raise", "ignore", "drop")
+        if out_of_bounds not in options:
+            str_options = ", ".join(options)
+            raise ValueError(
+                f"out_of_bounds must be one of {str_options}, "
+                f"received: {out_of_bounds}"
+            )
+
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
         if x.shape != y.shape:
@@ -1319,14 +1334,47 @@ class Ugrid2d(AbstractUgrid):
         dim = self.face_dimension
         xy = np.column_stack([x, y])
         index = self.locate_points(xy)
+
+        multiplier = None
+        keep = slice(None, None)  # keep all by default
         valid = index != -1
-        index = index[valid]
+        if not valid.all():
+            if out_of_bounds == "raise":
+                raise ValueError("Not all points are located inside of the grid.")
+            elif out_of_bounds in ("warn", "ignore"):
+                if out_of_bounds == "warn":
+                    warnings.warn(
+                        "Not all points are located inside of the grid. "
+                        "Out of bounds points are marked by NaN."
+                    )
+
+                # Mask the out_of_bounds points with NaN (they will be indexed
+                # with -1). Multiply valid values by 1.0, multiply outside
+                # values by NaN. Note that multiplying a dask array with a
+                # numpy array will result a dask array, so this doesn't break
+                # lazy evaluation.
+                multiplier = xr.DataArray(
+                    data=np.where(valid, 1.0, np.nan), dims=(dim,)
+                )
+
+            elif out_of_bounds == "drop":
+                index = index[valid]
+                keep = valid
+
+            else:
+                # This code shouldn't be reachable due to check up top.
+                raise ValueError("invalid out_of_bounds options")
+
         coords = {
-            f"{self.name}_index": (dim, np.arange(len(valid))[valid]),
-            f"{self.name}_x": (dim, xy[valid, 0]),
-            f"{self.name}_y": (dim, xy[valid, 1]),
+            f"{self.name}_index": (dim, np.arange(len(xy))[keep]),
+            f"{self.name}_x": (dim, xy[keep, 0]),
+            f"{self.name}_y": (dim, xy[keep, 1]),
         }
-        return obj.isel({dim: index}).assign_coords(coords)
+        selection = obj.isel({dim: index}).assign_coords(coords)
+        if multiplier is not None:
+            selection = selection * multiplier
+
+        return selection
 
     def intersect_line(self, obj, start: Sequence[float], end: Sequence[float]):
         """

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -129,7 +129,7 @@ class AbstractUgrid(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def sel_points(self, obj, x, y, out_bounds):
+    def sel_points(self, obj, x, y, out_bounds, fill_value):
         pass
 
     @abc.abstractmethod

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -129,7 +129,7 @@ class AbstractUgrid(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def sel_points(self):
+    def sel_points(self, obj, x, y, out_bounds):
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
Provide some options instead.

Fixes #100

Both this and the changing weights of the regridder reductions are breaking changes, the next version should be a bigger increment in version number.