### PR TITLE
Use a FILL_VALUE=-1 everywhere

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,13 +18,13 @@ Fixed
   tesselations); this dense array had fill (hard-coded) values of -1,
   potentially differing from the grid's fill value. This lead to a number of
   errors for methods relying on voronoi tesselations (such as contour plots)
-  if the fill value of the grid was not -1.
-- Internally, a ``FILL_VALUE = -1`` is now used everywhere in connectivity
-  arrays, and fill values are no longer passed for internal methods; a value of
-  -1 is always assumed. When converting the grid (back) to a dataset with
-  :meth:`xugrid.Ugrid1d.to_dataset` or :meth:`xugrid.Ugrid2d.to_dataset`, the
-  fill value is set back to its original value; the fill value is also set when
-  calling :meth:`xugrid.UgridDataArrayAccessor.to_netcdf` or
+  if the fill value of the grid was not -1. Internally, a ``FILL_VALUE = -1``
+  is now used everywhere in connectivity arrays, and fill values are no longer
+  passed for internal methods; a value of -1 is always assumed. When converting
+  the grid (back) to a dataset with :meth:`xugrid.Ugrid1d.to_dataset` or
+  :meth:`xugrid.Ugrid2d.to_dataset`, the fill value is set back to its original
+  value; the fill value is also set when calling
+  :meth:`xugrid.UgridDataArrayAccessor.to_netcdf` or
   :meth:`xugrid.UgridDatasetAccessor.to_netcdf`.
 
 [0.12.0] 2024-09-03

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,9 @@ Fixed
   arrays, and fill values are no longer passed for internal methods; a value of
   -1 is always assumed. When converting the grid (back) to a dataset with
   :meth:`xugrid.Ugrid1d.to_dataset` or :meth:`xugrid.Ugrid2d.to_dataset`, the
-  fill value is set back to its original value.
+  fill value is set back to its original value; the fill value is also set when
+  calling :meth:`xugrid.UgridDataArrayAccessor.to_netcdf` or
+  :meth:`xugrid.UgridDatasetAccessor.to_netcdf`.
 
 [0.12.0] 2024-09-03
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,25 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- Release 0.12.0 changed the return type of the face node connectivity of
+  :attr:`xugrid.Ugrid2d.voronoi_topology` from a `scipy.sparse.coo_matrix` to
+  an ordinary `np.array` of integers (and similarly for internal voronoi
+  tesselations); this dense array had fill (hard-coded) values of -1,
+  potentially differing from the grid's fill value. This lead to a number of
+  errors for methods relying on voronoi tesselations (such as contour plots)
+  if the fill value of the grid was not -1.
+- Internally, a ``FILL_VALUE = -1`` is now used everywhere in connectivity
+  arrays, and fill values are no longer passed for internal methods; a value of
+  -1 is always assumed. When converting the grid (back) to a dataset with
+  :meth:`xugrid.Ugrid1d.to_dataset` or :meth:`xugrid.Ugrid2d.to_dataset`, the
+  fill value is set back to its original value.
+
 [0.12.0] 2024-09-03
 -------------------
 

--- a/examples-dev/voronoi.py
+++ b/examples-dev/voronoi.py
@@ -19,6 +19,7 @@ For simplicity this example will only deal with (bare) ``numpy`` and
 modules, should you not want to rely on more complex dependencies such as
 ``xugrid`` and ``xarray``.
 """
+# %%
 import matplotlib.pyplot as plt
 import matplotlib.tri as mtri
 import numpy as np
@@ -107,12 +108,12 @@ def comparison_plot(
         sharex=True,
     )
 
-    edges0, _ = connectivity.edge_connectivity(faces0, -1)
+    edges0, _ = connectivity.edge_connectivity(faces0)
     edge_plot(vertices0, edges0, ax0, colors="black")
     ax0.scatter(*centroids0.T, color="red")
     ax0.scatter(*vertices0.T, color="black")
 
-    edges1, _ = connectivity.edge_connectivity(faces1, -1)
+    edges1, _ = connectivity.edge_connectivity(faces1)
     edge_plot(vertices0, edges0, ax1, colors="black")
     edge_plot(vertices1, edges1, ax1, colors="red")
 
@@ -132,7 +133,7 @@ def comparison_plot(
 vertices, faces = generate_disk(5, 2)
 centroids = vertices[faces].mean(axis=1)
 
-node_face_connectivity = connectivity.invert_dense_to_sparse(faces, -1)
+node_face_connectivity = connectivity.invert_dense_to_sparse(faces)
 voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     node_face_connectivity,
     vertices,
@@ -158,10 +159,8 @@ comparison_plot(vertices, faces, centroids, voronoi_vertices, voronoi_faces)
 # The ``voronoi_topology`` is capable of preserving the exterior exactly, but
 # this requires more topological information.
 
-edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(
-    faces, -1
-)
-edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity, -1)
+edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(faces)
+edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity)
 voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     node_face_connectivity,
     vertices,
@@ -189,11 +188,9 @@ vertices = vertices[np.unique(new.ravel())]
 faces = connectivity.renumber(new)
 centroids = vertices[faces].mean(axis=1)
 
-node_face_connectivity = connectivity.invert_dense_to_sparse(faces, -1)
-edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(
-    faces, -1
-)
-edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity, -1)
+node_face_connectivity = connectivity.invert_dense_to_sparse(faces)
+edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(faces)
+edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity)
 voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     node_face_connectivity,
     vertices,
@@ -215,11 +212,9 @@ comparison_plot(vertices, faces, centroids, voronoi_vertices, voronoi_faces)
 # of the original mesh altogether. We still add an orthogonal projection of
 # every centroid to exterior edges.
 
-node_face_connectivity = connectivity.invert_dense_to_sparse(faces, -1)
-edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(
-    faces, -1
-)
-edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity, -1)
+node_face_connectivity = connectivity.invert_dense_to_sparse(faces)
+edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(faces)
+edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity)
 voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     node_face_connectivity,
     vertices,
@@ -237,11 +232,9 @@ comparison_plot(vertices, faces, centroids, voronoi_vertices, voronoi_faces)
 # exactly. Alternatively, we can choose to skip the exterior vertex if it
 # creates a concave face:
 
-node_face_connectivity = connectivity.invert_dense_to_sparse(faces, -1)
-edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(
-    faces, -1
-)
-edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity, -1)
+node_face_connectivity = connectivity.invert_dense_to_sparse(faces)
+edge_node_connectivity, face_edge_connectivity = connectivity.edge_connectivity(faces)
+edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity)
 voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     node_face_connectivity,
     vertices,
@@ -263,7 +256,7 @@ nodes0, faces0, face_index0, _ = voronoi.voronoi_topology(
     vertices,
     centroids,
 )
-edges0, _ = connectivity.edge_connectivity(faces0, -1)
+edges0, _ = connectivity.edge_connectivity(faces0)
 
 nodes1, faces1, face_index1, _ = voronoi.voronoi_topology(
     node_face_connectivity,
@@ -274,7 +267,7 @@ nodes1, faces1, face_index1, _ = voronoi.voronoi_topology(
     add_exterior=True,
     add_vertices=False,
 )
-edges1, _ = connectivity.edge_connectivity(faces1, -1)
+edges1, _ = connectivity.edge_connectivity(faces1)
 
 nodes2, faces2, _, _ = voronoi.voronoi_topology(
     node_face_connectivity,
@@ -285,7 +278,7 @@ nodes2, faces2, _, _ = voronoi.voronoi_topology(
     add_exterior=True,
     add_vertices=True,
 )
-edges2, _ = connectivity.edge_connectivity(faces2, -1)
+edges2, _ = connectivity.edge_connectivity(faces2)
 
 nodes3, faces3, face_index3, node_map3 = voronoi.voronoi_topology(
     node_face_connectivity,
@@ -297,7 +290,7 @@ nodes3, faces3, face_index3, node_map3 = voronoi.voronoi_topology(
     add_vertices=True,
     skip_concave=True,
 )
-edges3, _ = connectivity.edge_connectivity(faces3, -1)
+edges3, _ = connectivity.edge_connectivity(faces3)
 
 fig, axes = plt.subplots(
     nrows=1,
@@ -415,3 +408,5 @@ edge_plot(nodes2, edges2, ax2, colors="black")
 
 ax0.set_xlim(-1.5, 1.5)
 ax0.set_ylim(-1.5, 1.5)
+
+# %%

--- a/examples-dev/voronoi.py
+++ b/examples-dev/voronoi.py
@@ -25,6 +25,8 @@ import matplotlib.tri as mtri
 import numpy as np
 from matplotlib.collections import LineCollection, PolyCollection
 
+from xugrid.constants import FILL_VALUE  # equals -1
+
 # %%
 # From xugrid, we need only import the ``connectivity`` and ``voronoi``
 # modules. The functions in these modules depend only on ``numpy`` and
@@ -69,7 +71,7 @@ def edge_plot(vertices, edge_nodes, ax, **kwargs):
     edge_coords = np.empty((n_edge, 2, 2), dtype=float)
     node_0 = edge_nodes[:, 0]
     node_1 = edge_nodes[:, 1]
-    valid = (node_0 != -1) & (node_1 != -1)
+    valid = (node_0 != FILL_VALUE) & (node_1 != FILL_VALUE)
     node_0 = node_0[valid]
     node_1 = node_1[valid]
     edge_coords[:, 0, 0] = vertices[node_0, 0]
@@ -85,7 +87,7 @@ def edge_plot(vertices, edge_nodes, ax, **kwargs):
 def face_plot(vertices, face_nodes, ax, **kwargs):
     vertices = vertices[face_nodes]
     # Replace fill value; PolyCollection ignores NaN.
-    vertices[face_nodes == -1] = np.nan
+    vertices[face_nodes == FILL_VALUE] = np.nan
     collection = PolyCollection(vertices, **kwargs)
     primitive = ax.add_collection(collection)
     ax.autoscale()
@@ -127,8 +129,6 @@ def comparison_plot(
 # %%
 # Let's start by generating a simple unstructured mesh and use only its
 # centroids to generate a voronoi tesselation.
-#
-# Note: ``-1`` functions as the fill value in this example.
 
 vertices, faces = generate_disk(5, 2)
 centroids = vertices[faces].mean(axis=1)

--- a/examples-dev/voronoi.py
+++ b/examples-dev/voronoi.py
@@ -63,12 +63,12 @@ def generate_disk(partitions: int, depth: int):
     return np.column_stack((x, y)), triang.triangles
 
 
-def edge_plot(vertices, edge_nodes, ax, fill_value=-1, **kwargs):
+def edge_plot(vertices, edge_nodes, ax, **kwargs):
     n_edge = len(edge_nodes)
     edge_coords = np.empty((n_edge, 2, 2), dtype=float)
     node_0 = edge_nodes[:, 0]
     node_1 = edge_nodes[:, 1]
-    valid = (node_0 != fill_value) & (node_1 != fill_value)
+    valid = (node_0 != -1) & (node_1 != -1)
     node_0 = node_0[valid]
     node_1 = node_1[valid]
     edge_coords[:, 0, 0] = vertices[node_0, 0]
@@ -81,10 +81,10 @@ def edge_plot(vertices, edge_nodes, ax, fill_value=-1, **kwargs):
     return primitive
 
 
-def face_plot(vertices, face_nodes, ax, fill_value=-1, **kwargs):
+def face_plot(vertices, face_nodes, ax, **kwargs):
     vertices = vertices[face_nodes]
     # Replace fill value; PolyCollection ignores NaN.
-    vertices[face_nodes == fill_value] = np.nan
+    vertices[face_nodes == -1] = np.nan
     collection = PolyCollection(vertices, **kwargs)
     primitive = ax.add_collection(collection)
     ax.autoscale()
@@ -168,7 +168,6 @@ voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=True,
 )
@@ -201,7 +200,6 @@ voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=True,
 )
@@ -228,7 +226,6 @@ voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=False,
 )
@@ -251,7 +248,6 @@ voronoi_vertices, voronoi_faces, face_index, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=True,
     skip_concave=True,
@@ -275,7 +271,6 @@ nodes1, faces1, face_index1, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=False,
 )
@@ -287,7 +282,6 @@ nodes2, faces2, _, _ = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=True,
 )
@@ -299,7 +293,6 @@ nodes3, faces3, face_index3, node_map3 = voronoi.voronoi_topology(
     centroids,
     edge_face_connectivity=edge_face_connectivity,
     edge_node_connectivity=edge_node_connectivity,
-    fill_value=-1,
     add_exterior=True,
     add_vertices=True,
     skip_concave=True,
@@ -342,10 +335,10 @@ data = centroids[:, 0] + centroids[:, 1]
 # fourth option, since it includes some vertices of the original mesh, which
 # are connected to multiple faces.
 
-triangles0, face_triangles0 = connectivity.triangulate(faces0, -1)
+triangles0, face_triangles0 = connectivity.triangulate(faces0)
 triangulation0 = mtri.Triangulation(nodes0[:, 0], nodes0[:, 1], triangles0)
 
-triangles1, face_triangles1 = connectivity.triangulate(faces1, -1)
+triangles1, face_triangles1 = connectivity.triangulate(faces1)
 triangulation1 = mtri.Triangulation(nodes1[:, 0], nodes1[:, 1], triangles1)
 
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -5,6 +5,7 @@ import shapely
 import xarray as xr
 
 from xugrid import conversion as cv
+from xugrid.constants import FILL_VALUE
 
 
 @pytest.fixture(scope="function")
@@ -32,7 +33,6 @@ def line_gdf():
 def triangle_mesh():
     x = np.array([0.0, 1.0, 1.0, 2.0])
     y = np.array([0.0, 0.0, 1.0, 0.0])
-    fill_value = -1
     # Two triangles
     faces = np.array(
         [
@@ -40,22 +40,21 @@ def triangle_mesh():
             [1, 3, 2],
         ]
     )
-    return x, y, faces, fill_value
+    return x, y, faces
 
 
 @pytest.fixture(scope="function")
 def mixed_mesh():
     x = np.array([0.0, 1.0, 1.0, 2.0, 2.0])
     y = np.array([0.0, 0.0, 1.0, 0.0, 1.0])
-    fill_value = -1
     # Triangle, quadrangle
     faces = np.array(
         [
-            [0, 1, 2, fill_value],
+            [0, 1, 2, FILL_VALUE],
             [1, 3, 4, 2],
         ]
     )
-    return x, y, faces, fill_value
+    return x, y, faces
 
 
 @pytest.fixture(scope="function")
@@ -111,14 +110,13 @@ def test_edges_geos_roundtrip(line):
 # Cannot use fixtures in parametrize:
 # https://github.com/pytest-dev/pytest/issues/349
 def _faces_geos_roundtrip(mesh):
-    x, y, c, fv = mesh
-    actual = cv.faces_to_polygons(x, y, c, fv)
-    x_back, y_back, c_back, fv_back = cv.polygons_to_faces(actual)
-    polygons_back = cv.faces_to_polygons(x_back, y_back, c_back, fv_back)
+    x, y, c = mesh
+    actual = cv.faces_to_polygons(x, y, c)
+    x_back, y_back, c_back = cv.polygons_to_faces(actual)
+    polygons_back = cv.faces_to_polygons(x_back, y_back, c_back)
     assert np.array_equal(x, x_back)
     assert np.array_equal(y, y_back)
     assert np.array_equal(c, c_back)
-    assert fv == fv_back
     assert np.array_equal(actual, polygons_back)
 
 

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -1051,6 +1051,19 @@ def test_tesselate_centroidal_voronoi():
     voronoi = grid.tesselate_centroidal_voronoi()
     assert voronoi.n_face == 7
 
+    faces = FACES.copy()
+    faces[faces == -1] = -999
+    grid = xugrid.Ugrid2d(
+        node_x=VERTICES[:, 0],
+        node_y=VERTICES[:, 1],
+        fill_value=-999,
+        face_node_connectivity=faces,
+    )
+    voronoi = grid.tesselate_centroidal_voronoi(add_exterior=True)
+    vfaces = voronoi.face_node_connectivity
+    fill_nodes = vfaces[vfaces < 0]
+    assert (fill_nodes == -1).all()
+
 
 def test_tesselate_circumcenter_voronoi():
     grid = grid2d()

--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -1191,6 +1191,20 @@ def test_fm_fillvalue_startindex_isel():
     # xugrid 0.6.0 raises "ValueError: Invalid edge_node_connectivity"
     uds.isel({uds.grid.face_dimension: [1]})
 
+    # Check internal fill value. Should be FILL_VALUE
+    grid = uds.ugrid.grid
+    assert (grid.face_node_connectivity != -999).all()
+    gridds = grid.to_dataset()
+    # Should be set back to the origina fill value.
+    assert (gridds["mesh2d_face_nodes"] != xugrid.constants.FILL_VALUE).all()
+
+    # And similarly for the UgridAccessors.
+    ds = uds.ugrid.to_dataset()
+    assert (ds["mesh2d_face_nodes"] != xugrid.constants.FILL_VALUE).all()
+
+    ds_uda = uds["mesh2d_facevar"].ugrid.to_dataset()
+    assert (ds_uda["mesh2d_face_nodes"] != xugrid.constants.FILL_VALUE).all()
+
 
 def test_fm_facenodeconnectivity_fillvalue():
     """

--- a/tests/test_voronoi.py
+++ b/tests/test_voronoi.py
@@ -79,7 +79,6 @@ class TestVoronoi:
                 [3.0, 2.0],  # 11
             ]
         )
-        self.fill_value = -1
         self.face_node_connectivity = np.array(
             [
                 [0, 1, 5, 4],
@@ -91,18 +90,15 @@ class TestVoronoi:
             ]
         )
         self.node_face_connectivity = connectivity.invert_dense_to_sparse(
-            self.face_node_connectivity, self.fill_value
+            self.face_node_connectivity
         )
         (
             self.edge_node_connectivity,
             face_edge_connectivity,
         ) = connectivity.edge_connectivity(
             self.face_node_connectivity,
-            self.fill_value,
         )
-        self.edge_face_connectivity = connectivity.invert_dense(
-            face_edge_connectivity, self.fill_value
-        )
+        self.edge_face_connectivity = connectivity.invert_dense(face_edge_connectivity)
         self.centroids = np.array(
             [
                 [0.5, 0.5],
@@ -160,7 +156,6 @@ class TestVoronoi:
             self.node_face_connectivity,
             self.edge_face_connectivity,
             self.edge_node_connectivity,
-            fill_value=self.fill_value,
         )
         expected_i = np.array([1, 1, 2, 2, 4, 4, 7, 7, 9, 9, 10, 10])
         expected_j = np.array([0, 1, 1, 2, 0, 3, 2, 5, 3, 4, 4, 5])
@@ -178,7 +173,6 @@ class TestVoronoi:
         ) = voronoi.exterior_vertices(
             self.edge_face_connectivity,
             self.edge_node_connectivity,
-            self.fill_value,
             self.vertices,
             self.centroids,
             add_vertices=False,
@@ -223,7 +217,6 @@ class TestVoronoi:
             self.centroids,
             self.edge_face_connectivity,
             self.edge_node_connectivity,
-            self.fill_value,
             add_exterior=True,
         )
         expected_vertices = rowsort(
@@ -240,7 +233,6 @@ class TestVoronoi:
             self.centroids,
             self.edge_face_connectivity,
             self.edge_node_connectivity,
-            self.fill_value,
             add_exterior=True,
             add_vertices=True,
         )

--- a/xugrid/constants.py
+++ b/xugrid/constants.py
@@ -22,6 +22,10 @@ LineArray = np.ndarray
 PolygonArray = np.ndarray
 SparseMatrix = Union[coo_matrix, csr_matrix]
 
+# Internally we always use a fill value of -1. This ensures we can always index
+# with the fill value as well, since any array will have at least size 1.
+FILL_VALUE = -1
+
 
 class Point(NamedTuple):
     x: float

--- a/xugrid/conversion.py
+++ b/xugrid/conversion.py
@@ -11,6 +11,7 @@ import numpy as np
 import xarray as xr
 
 from xugrid.constants import (
+    FILL_VALUE,
     FloatArray,
     IntArray,
     IntDType,
@@ -48,9 +49,9 @@ def edges_to_linestrings(
 
 
 def faces_to_polygons(
-    x: FloatArray, y: FloatArray, face_node_connectivity: IntArray, fill_value: int
+    x: FloatArray, y: FloatArray, face_node_connectivity: IntArray
 ) -> PolygonArray:
-    is_data = face_node_connectivity != fill_value
+    is_data = face_node_connectivity != FILL_VALUE
     m_per_row = is_data.sum(axis=1)
     i = np.repeat(np.arange(len(face_node_connectivity)), m_per_row)
     c = face_node_connectivity.ravel()[is_data.ravel()]
@@ -98,7 +99,6 @@ def polygons_to_faces(
     n = len(polygons)
     m_per_row = np.bincount(indices)
     m = m_per_row.max()
-    fill_value = -1
     # Allocate 2D array and create a flat view of the dense connectivity
     conn = np.empty((n, m), dtype=IntDType)
     flat_conn = conn.ravel()
@@ -108,10 +108,10 @@ def polygons_to_faces(
         valid = slice(None)  # a[:] equals a[slice(None)]
     else:
         valid = ragged_index(n, m, m_per_row).ravel()
-        flat_conn[~valid] = fill_value
+        flat_conn[~valid] = FILL_VALUE
     flat_conn[valid] = inverse
     x, y = contiguous_xy(unique)
-    return x, y, conn, fill_value
+    return x, y, conn
 
 
 def _scalar_spacing(coords, spacing):

--- a/xugrid/plot/plot.py
+++ b/xugrid/plot/plot.py
@@ -511,7 +511,7 @@ def pcolormesh(grid, da, ax, **kwargs):
         raise ValueError("pcolormesh only supports data on faces")
 
     nodes = grid.node_coordinates
-    faces, _ = close_polygons(grid.face_node_connectivity, grid.fill_value)
+    faces, _ = close_polygons(grid.face_node_connectivity)
     vertices = nodes[faces]
 
     # PolyCollection takes a norm, but not vmin, vmax.

--- a/xugrid/regrid/unstructured.py
+++ b/xugrid/regrid/unstructured.py
@@ -152,7 +152,6 @@ class UnstructuredGrid2d:
             grid.centroids,
             edge_face_connectivity=grid.edge_face_connectivity,
             edge_node_connectivity=grid.edge_node_connectivity,
-            fill_value=grid.fill_value,
             add_exterior=True,
             add_vertices=True,
             skip_concave=True,

--- a/xugrid/ugrid/partitioning.py
+++ b/xugrid/ugrid/partitioning.py
@@ -6,7 +6,7 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from xugrid.constants import IntArray, IntDType
+from xugrid.constants import FILL_VALUE, IntArray, IntDType
 from xugrid.core.wrap import UgridDataArray, UgridDataset
 from xugrid.ugrid.connectivity import renumber
 from xugrid.ugrid.ugridbase import UgridType
@@ -115,17 +115,17 @@ def _merge_connectivity(gathered, slices):
     return merged, indexes
 
 
-def merge_faces(grids, node_inverse, fill_value: int = -1):
+def merge_faces(grids, node_inverse):
     node_offsets = tuple(accumulate([0] + [grid.n_node for grid in grids]))
     n_face = [grid.n_face for grid in grids]
     n_max_node = max(grid.n_max_node_per_face for grid in grids)
     slices = (0,) + tuple(accumulate(n_face))
 
-    all_faces = np.full((sum(n_face), n_max_node), fill_value, dtype=IntDType)
+    all_faces = np.full((sum(n_face), n_max_node), FILL_VALUE, dtype=IntDType)
     for grid, face_offset, node_offset in zip(grids, slices, node_offsets):
         faces = grid.face_node_connectivity
         n_face, n_node_per_face = faces.shape
-        valid = faces != grid.fill_value
+        valid = faces != FILL_VALUE
         all_faces[face_offset : face_offset + n_face, :n_node_per_face][
             valid
         ] = node_inverse[faces[valid] + node_offset]

--- a/xugrid/ugrid/snapping.py
+++ b/xugrid/ugrid/snapping.py
@@ -402,7 +402,7 @@ def create_snap_to_grid_dataframe(
     vertices = topology.node_coordinates
     edge_centroids = topology.edge_coordinates
     face_edge_connectivity = topology.face_edge_connectivity
-    A = connectivity.to_sparse(face_edge_connectivity, fill_value=-1)
+    A = connectivity.to_sparse(face_edge_connectivity)
     n, m = A.shape
     face_edge_connectivity = AdjacencyMatrix(A.indices, A.indptr, A.nnz, n, m)
 

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike
 import xugrid
 from xugrid import conversion
 from xugrid.constants import (
+    FILL_VALUE,
     BoolArray,
     FloatArray,
     FloatDType,
@@ -133,7 +134,6 @@ class Ugrid1d(AbstractUgrid):
             + list(connectivity.values())
             + list(chain.from_iterable(chain.from_iterable(coordinates.values())))
         )
-        fill_value = -1
 
         # Take the first coordinates by default.
         # They can be reset with .set_node_coords()
@@ -144,7 +144,7 @@ class Ugrid1d(AbstractUgrid):
 
         edge_nodes = connectivity["edge_node_connectivity"]
         edge_node_connectivity = cls._prepare_connectivity(
-            ds[edge_nodes], fill_value, dtype=IntDType
+            ds[edge_nodes], FILL_VALUE, dtype=IntDType
         ).to_numpy()
 
         indexes["node_x"] = x_index
@@ -154,7 +154,7 @@ class Ugrid1d(AbstractUgrid):
         return cls(
             node_x_coordinates,
             node_y_coordinates,
-            fill_value,
+            FILL_VALUE,
             edge_node_connectivity,
             name=topology,
             dataset=dataset[ugrid_vars],
@@ -211,7 +211,7 @@ class Ugrid1d(AbstractUgrid):
         return cls(
             mesh.node_x,
             mesh.node_y,
-            fill_value=-1,
+            fill_value=FILL_VALUE,
             edge_node_connectivity=mesh.edge_nodes.reshape((-1, 2)),
             name=name,
             projected=projected,
@@ -389,8 +389,7 @@ class Ugrid1d(AbstractUgrid):
             )
 
         x, y, edge_node_connectivity = conversion.linestrings_to_edges(geometry)
-        fill_value = -1
-        return Ugrid1d(x, y, fill_value, edge_node_connectivity, crs=crs)
+        return Ugrid1d(x, y, FILL_VALUE, edge_node_connectivity, crs=crs)
 
     def to_pygeos(self, dim):
         from warnings import warn

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -485,7 +485,8 @@ class AbstractUgrid(abc.ABC):
 
     def _set_fillvalue(self, connectivity: IntArray) -> IntArray:
         c = connectivity.copy()
-        c[c == FILL_VALUE] = self.fill_value
+        if self.fill_value != FILL_VALUE:
+            c[c == FILL_VALUE] = self.fill_value
         return c
 
     def _precheck(self, multi_index):

--- a/xugrid/ugrid/ugridbase.py
+++ b/xugrid/ugrid/ugridbase.py
@@ -10,7 +10,7 @@ import xarray as xr
 from numpy.typing import ArrayLike
 from scipy.sparse import csr_matrix
 
-from xugrid.constants import BoolArray, FloatArray, IntArray
+from xugrid.constants import FILL_VALUE, BoolArray, FloatArray, IntArray
 from xugrid.ugrid import connectivity, conventions
 
 
@@ -483,6 +483,11 @@ class AbstractUgrid(abc.ABC):
             raise ValueError("connectivity contains negative values")
         return da.copy(data=cast)
 
+    def _set_fillvalue(self, connectivity: IntArray) -> IntArray:
+        c = connectivity.copy()
+        c[c == FILL_VALUE] = self.fill_value
+        return c
+
     def _precheck(self, multi_index):
         dim, index = multi_index.popitem()
         for check_dim, check_index in multi_index.items():
@@ -646,7 +651,7 @@ class AbstractUgrid(abc.ABC):
         """
         if self._node_edge_connectivity is None:
             self._node_edge_connectivity = connectivity.invert_dense_to_sparse(
-                self.edge_node_connectivity, self.fill_value
+                self.edge_node_connectivity
             )
         return self._node_edge_connectivity
 


### PR DESCRIPTION
The external fill value is only used when converting back to dataset.

Fixes #298

(Should've done this long ago, there was more than one place where a fill value != -1 might have resulted in an error.)

The error of #298 makes the last release unfortunately quite broken for datasets where a fill_value != -1 was used.

@veenstrajelmer, you might want to run the dfm tools tests with this as well. The fill values were used in a lot of places, it's possible the xugrid test still have some soft spots. If there are any failures, we should patch them and add them as new tests.