### PR TITLE
Omit x, y coordinates, x & y bounds from conversion

### DIFF
--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -937,7 +937,7 @@ class TestFromStructured:
                 }
             },
         )
-        assert set(uds.data_vars) == {"a", "b", "c", "grid_x", "grid_y"}
+        assert set(uds.data_vars) == {"a", "b", "c"}
         assert uds["a"].dims == ("layer", "mesh2d_nFaces")
         assert uds["b"].dims == ("x",)
         assert uds["c"].dims == ()


### PR DESCRIPTION
X and Y coords aren't relevant; they're stored in the Ugrid topology.

In particular, the original bounds might be somewhat messy (e.g. the triangle stuff...). If user want the coordinates, they can use https://deltares.github.io/xugrid/api/xugrid.UgridDatasetAccessor.assign_face_coords.html

Which are nice and consistent (i.e. counterclockwise, and without repeated vertices).