### PR TITLE
Add network gridder

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -167,6 +167,16 @@ data, represented as xugrid objects.
        OverlapRegridder
        RelativeOverlapRegridder
 
+Gridding
+--------
+
+Gridding is the process of converting 1d networks to 2d grids. 
+
+.. autosummary::
+      :toctree: api/
+
+       NetworkGridder
+
 Plotting
 --------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ Added
   :attr:`xugrid.Ugrid2d.edge_edge_connectivity`.
 - Added :meth:`xugrid.Ugrid1d.refine_by_vertices` to refine a network with
   inserted vertices.
+- Added :class:`xugrid.NetworkGridder` to grid networks (Ugrid1d) to a 2D grid.
+  Currently only support gridding to a Ugrid2d grid.
 
 [0.12.4] 2025-03-05
 -------------------

--- a/examples/network_gridder.py
+++ b/examples/network_gridder.py
@@ -1,0 +1,142 @@
+"""
+Network gridder example
+=======================
+
+In this example, we demonstrate how to interpolate and grid
+data from a 1D network grid to a 2D structured grid.
+"""
+
+# %%
+# We'll start by setting up the structured grid first and converting it to a
+# Ugrid2d grid.
+import numpy as np
+import xarray as xr
+
+import xugrid as xu
+
+
+def make_structured_grid(nrow, ncol, dx, dy):
+    if dy >= 0:
+        raise ValueError("dy must be negative.")
+
+    shape = nrow, ncol
+
+    xmin = 0.0
+    xmax = dx * ncol
+    ymin = 0.0
+    ymax = abs(dy) * nrow
+    dims = ("y", "x")
+
+    y = np.arange(ymax, ymin, dy) + 0.5 * dy
+    x = np.arange(xmin, xmax, dx) + 0.5 * dx
+    coords = {"y": y, "x": x}
+
+    return xr.DataArray(np.ones(shape, dtype=np.int32), coords=coords, dims=dims)
+
+
+structured_grid = make_structured_grid(10, 10, 1.5, -1.5)
+uda = xu.UgridDataArray.from_structured2d(structured_grid)
+ugrid2d = uda.ugrid.grid
+
+uda
+
+# %%
+#
+# Next, we create a 1D network. This network consists of 5 nodes and 4 edges.
+# At node 2 the network forks to two branches. The data is located no the nodes.
+
+node_xy = np.array(
+    [
+        [0.0, 0.0],
+        [5.0, 5.0],
+        [10.0, 5.0],
+        [15.0, 0.0],
+        [15.0, 10.0],
+    ]
+)
+edge_nodes = np.array(
+    [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [2, 4],
+    ]
+)
+network = xu.Ugrid1d(*node_xy.T, -1, edge_nodes)
+data = xr.DataArray(
+    np.array([1, 1.5, 2, 4, -4], dtype=float), dims=(network.node_dimension,)
+)
+uda_1d = xu.UgridDataArray(data, grid=network)
+
+uda_1d
+
+# %%
+#
+# Let's plot the 1D network on top of the 2D grid. The 1D network is shown in
+# gray, the 2D grid in blue. The network's nodes are colored by data values.
+
+uda_1d.ugrid.plot()
+uda_1d.ugrid.grid.plot(color="gray", alpha=0.5)
+ugrid2d.plot()
+
+# %% Intersect edges
+#
+# Let's first
+
+edges_coords = ugrid2d.node_coordinates[ugrid2d.edge_node_connectivity]
+_, _, intersections_xy = network.intersect_edges(edges_coords)
+
+_intersections_xy = np.unique(intersections_xy, axis=0)
+refined_network, refined_node_index = network.refine_by_vertices(
+    _intersections_xy, return_index=True
+)
+
+# %%
+refined_data = xr.DataArray(
+    np.empty_like(refined_network.node_x), dims=(refined_network.node_dimension,)
+)
+uda_1d_refined = xu.UgridDataArray(refined_data, grid=refined_network)
+
+# %%
+# Set data
+node_dim = uda_1d.ugrid.grid.node_dimension
+uda_1d_refined.data[uda_1d[node_dim].data] = uda_1d.data
+uda_1d_refined.data[refined_node_index] = np.nan
+
+# Interpolate nodes
+uda_1d_interpolated = uda_1d_refined.ugrid.laplace_interpolate()
+
+# %%
+# Set data to edge centroids
+edge_data = xr.DataArray(
+    data=uda_1d_interpolated.data[refined_network.edge_node_connectivity].mean(axis=1),
+    dims=(refined_network.edge_dimension,),
+)
+uda_1d_edge = xu.UgridDataArray(edge_data, grid=refined_network)
+
+# %%
+from xugrid.regrid.gridder import NetworkGridder
+
+gridder = NetworkGridder(
+    source=uda_1d_edge.ugrid.grid,
+    target=ugrid2d,
+    method="mean",
+)
+
+# %%
+network_gridded = gridder.regrid(uda_1d_edge)
+
+# %%
+network_gridded.ugrid.plot()
+
+# %%
+
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots()
+
+ugrid2d.plot(ax=ax)
+plt.scatter(*intersections_xy.T)
+
+
+# %%

--- a/tests/test_regrid/test_network_gridder.py
+++ b/tests/test_regrid/test_network_gridder.py
@@ -46,7 +46,7 @@ def network():
     return xu.UgridDataArray(data, grid=ugrid1d)
 
 
-def test_network_gridder__init(network, unstructured_grid):
+def test_network_gridder_init__unstructured(network, unstructured_grid):
     gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
 
     assert isinstance(gridder, xu.NetworkGridder)
@@ -57,7 +57,7 @@ def test_network_gridder__init(network, unstructured_grid):
     assert gridder._weights.nnz == 8
 
 
-def test_network_gridder__regrid(network, unstructured_grid):
+def test_network_gridder_regrid__unstructured(network, unstructured_grid):
     gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
     gridded = gridder.regrid(network)
 
@@ -77,3 +77,8 @@ def test_network_gridder__regrid(network, unstructured_grid):
     )
     np.testing.assert_allclose(grid_values[3], -4.0)
     np.testing.assert_allclose(grid_values[4], 4.0)
+
+
+def test_network_gridder_init__structured(network, structured_grid):
+    with pytest.raises(NotImplementedError):
+        xu.NetworkGridder(network, structured_grid, method="mean")

--- a/tests/test_regrid/test_network_gridder.py
+++ b/tests/test_regrid/test_network_gridder.py
@@ -1,2 +1,79 @@
-def test_network_gridder():
-    raise NotImplementedError("Test not implemented yet.")
+import numpy as np
+import pytest
+import xarray as xr
+
+import xugrid as xu
+
+
+@pytest.fixture(scope="function")
+def structured_grid():
+    dims = ("y", "x")
+    y = np.arange(3.5, -0.5, -1.0)
+    x = np.arange(0.5, 4.5, 1.0)
+    coords = {"y": y, "x": x}
+
+    return xr.DataArray(np.ones((4, 4), dtype=np.int32), coords=coords, dims=dims)
+
+
+@pytest.fixture(scope="function")
+def unstructured_grid(structured_grid):
+    return xu.UgridDataArray.from_structured2d(structured_grid)
+
+
+@pytest.fixture(scope="function")
+def network():
+    node_xy = np.array(
+        [
+            [0.0, 0.0],
+            [1.5, 1.5],
+            [2.5, 1.5],
+            [4.0, 0.0],
+            [4.0, 3.0],
+        ]
+    )
+    edge_nodes = np.array(
+        [
+            [0, 1],
+            [1, 2],
+            [2, 3],
+            [2, 4],
+        ]
+    )
+    ugrid1d = xu.Ugrid1d(*node_xy.T, -1, edge_nodes)
+    data = xr.DataArray(
+        np.array([1, 2, 4, -4], dtype=float), dims=(ugrid1d.edge_dimension,)
+    )
+    return xu.UgridDataArray(data, grid=ugrid1d)
+
+
+def test_network_gridder__init(network, unstructured_grid):
+    gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
+
+    assert isinstance(gridder, xu.NetworkGridder)
+    assert gridder._source.ugrid_topology == network.grid
+    assert gridder._target.ugrid_topology == unstructured_grid.grid
+    assert gridder._weights.n == unstructured_grid.grid.n_face
+    assert gridder._weights.m == network.grid.n_edge
+    assert gridder._weights.nnz == 8
+
+
+def test_network_gridder__regrid(network, unstructured_grid):
+    gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
+    gridded = gridder.regrid(network)
+
+    assert isinstance(gridded, type(unstructured_grid))
+    assert gridded.shape == unstructured_grid.shape
+    assert np.count_nonzero(np.isnan(gridded)) == 11
+
+    x_loc = [0.5, 1.5, 2.5, 3.5, 3.5]
+    y_loc = [0.5, 1.5, 1.5, 2.5, 0.5]
+    diag = 0.5 * np.sqrt(2)
+    grid_values = gridded.ugrid.sel_points(x=x_loc, y=y_loc)
+
+    np.testing.assert_allclose(grid_values[0], 1.0)
+    np.testing.assert_allclose(grid_values[1], (diag * 1 + 0.5 * 2) / (diag + 0.5))
+    np.testing.assert_allclose(
+        grid_values[2], (0.5 * 2 + diag * -4 + diag * 4) / (2 * diag + 0.5)
+    )
+    np.testing.assert_allclose(grid_values[3], -4.0)
+    np.testing.assert_allclose(grid_values[4], 4.0)

--- a/tests/test_regrid/test_network_gridder.py
+++ b/tests/test_regrid/test_network_gridder.py
@@ -1,0 +1,2 @@
+def test_network_gridder():
+    raise NotImplementedError("Test not implemented yet.")

--- a/tests/test_regrid/test_network_gridder.py
+++ b/tests/test_regrid/test_network_gridder.py
@@ -46,6 +46,25 @@ def network():
     return xu.UgridDataArray(data, grid=ugrid1d)
 
 
+@pytest.fixture(scope="function")
+def points_to_sample():
+    x_loc = np.array([0.5, 1.5, 2.5, 3.5, 3.5])
+    y_loc = np.array([0.5, 1.5, 1.5, 2.5, 0.5])
+    diag = 0.5 * np.sqrt(2)
+    expected_values = np.array(
+        [
+            1.0,
+            (diag * 1 + 0.5 * 2) / (diag + 0.5),  # 1 diagonal edge, 1 horizontal edge
+            (0.5 * 2 + diag * -4 + diag * 4)
+            / (2 * diag + 0.5),  # 2 diagonal edge, 1 horizontal edge
+            -4.0,
+            4.0,
+        ]
+    )
+
+    return x_loc, y_loc, expected_values
+
+
 def test_network_gridder_init__unstructured(network, unstructured_grid):
     gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
 
@@ -57,7 +76,9 @@ def test_network_gridder_init__unstructured(network, unstructured_grid):
     assert gridder._weights.nnz == 8
 
 
-def test_network_gridder_regrid__unstructured(network, unstructured_grid):
+def test_network_gridder_regrid__unstructured(
+    network, unstructured_grid, points_to_sample
+):
     gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
     gridded = gridder.regrid(network)
 
@@ -65,18 +86,34 @@ def test_network_gridder_regrid__unstructured(network, unstructured_grid):
     assert gridded.shape == unstructured_grid.shape
     assert np.count_nonzero(np.isnan(gridded)) == 11
 
-    x_loc = [0.5, 1.5, 2.5, 3.5, 3.5]
-    y_loc = [0.5, 1.5, 1.5, 2.5, 0.5]
-    diag = 0.5 * np.sqrt(2)
+    x_loc, y_loc, expected_values = points_to_sample
     grid_values = gridded.ugrid.sel_points(x=x_loc, y=y_loc)
 
-    np.testing.assert_allclose(grid_values[0], 1.0)
-    np.testing.assert_allclose(grid_values[1], (diag * 1 + 0.5 * 2) / (diag + 0.5))
-    np.testing.assert_allclose(
-        grid_values[2], (0.5 * 2 + diag * -4 + diag * 4) / (2 * diag + 0.5)
+    np.testing.assert_allclose(grid_values, expected_values)
+
+
+def test_network_gridder_regrid__unstructured_transient(
+    network, unstructured_grid, points_to_sample
+):
+    # Make transient network
+    times = [np.datetime64("2022-01-01"), np.datetime64("2023-01-01")]
+    time_multiplier = xr.DataArray([1.0, 2.0], dims="time", coords={"time": times})
+    network = (network * time_multiplier).transpose(
+        "time", network.ugrid.grid.core_dimension
     )
-    np.testing.assert_allclose(grid_values[3], -4.0)
-    np.testing.assert_allclose(grid_values[4], 4.0)
+
+    gridder = xu.NetworkGridder(network, unstructured_grid, method="mean")
+    gridded = gridder.regrid(network)
+
+    assert isinstance(gridded, type(unstructured_grid))
+    assert np.count_nonzero(np.isnan(gridded)) == 22
+
+    x_loc, y_loc, expected_values = points_to_sample
+    grid_values_t0 = gridded.isel(time=0).ugrid.sel_points(x=x_loc, y=y_loc)
+    grid_values_t1 = gridded.isel(time=1).ugrid.sel_points(x=x_loc, y=y_loc)
+
+    np.testing.assert_allclose(grid_values_t0, expected_values)
+    np.testing.assert_allclose(grid_values_t1, 2 * expected_values)
 
 
 def test_network_gridder_init__structured(network, structured_grid):

--- a/xugrid/__init__.py
+++ b/xugrid/__init__.py
@@ -16,6 +16,7 @@ from xugrid.core.dataarray_accessor import UgridDataArrayAccessor
 from xugrid.core.dataset_accessor import UgridDatasetAccessor
 from xugrid.core.wrap import UgridDataArray, UgridDataset
 from xugrid.plot import plot
+from xugrid.regrid.gridder import NetworkGridder
 from xugrid.regrid.regridder import (
     BarycentricInterpolator,
     CentroidLocatorRegridder,
@@ -60,6 +61,7 @@ __all__ = (
     "RelativeOverlapRegridder",
     "burn_vector_geometry",
     "earcut_triangulate_polygons",
+    "NetworkGridder",
     "UgridRolesAccessor",
     "merge_partitions",
     "polygonize",

--- a/xugrid/regrid/gridder.py
+++ b/xugrid/regrid/gridder.py
@@ -18,6 +18,10 @@ def convert_to_match(source, target):
     }
     types = set({type(target)})
     matched_type = PROMOTIONS[frozenset(types)]
+    if matched_type is StructuredGrid2d:
+        raise NotImplementedError(
+            "Gridding networks to structured grids is not yet supported. Convert to unstructured grid first by calling UgridDataArray.from_structured()"
+        )
     return source, target.convert_to(matched_type)
 
 

--- a/xugrid/regrid/gridder.py
+++ b/xugrid/regrid/gridder.py
@@ -1,0 +1,85 @@
+from typing import Callable, Union
+
+import xarray as xr
+
+import xugrid
+from xugrid.core.sparse import MatrixCSR
+from xugrid.regrid import reduce
+from xugrid.regrid.network import Network2d
+from xugrid.regrid.regridder import BaseRegridder, make_regrid, setup_grid
+from xugrid.regrid.structured import StructuredGrid2d
+from xugrid.regrid.unstructured import UnstructuredGrid2d
+
+
+def convert_to_match(source, target):
+    PROMOTIONS = {
+        frozenset({StructuredGrid2d}): StructuredGrid2d,
+        frozenset({UnstructuredGrid2d}): UnstructuredGrid2d,
+    }
+    types = set({type(target)})
+    matched_type = PROMOTIONS[frozenset(types)]
+    return source, target.convert_to(matched_type)
+
+
+class NetworkGridder(BaseRegridder):
+    """
+    Network gridder for 2D unstructured grids.
+
+    Parameters
+    ----------
+    grid: Ugrid1d
+        The grid to be used for the regridding.
+    """
+
+    _JIT_FUNCTIONS = {
+        k: make_regrid(f) for k, f in reduce.ABSOLUTE_OVERLAP_METHODS.items()
+    }
+
+    def __init__(
+        self,
+        source: "xugrid.Ugrid1d",
+        target: "xugrid.Ugrid2d",
+        method: Union[str, Callable] = "mean",
+    ):
+        self._source = Network2d(source)
+        self._target = setup_grid(target)
+        self._weights = None
+        self._compute_weights(self._source, self._target, relative=False)
+        self._setup_regrid(method)
+        return
+
+    @property
+    def weights(self):
+        return self.to_dataset()
+
+    @weights.setter
+    def weights(self, weights: MatrixCSR):
+        if not isinstance(weights, MatrixCSR):
+            raise TypeError(f"Expected MatrixCSR, received: {type(weights).__name__}")
+        self._weights = weights
+        return
+
+    @classmethod
+    def _weights_from_dataset(cls, dataset: xr.Dataset) -> MatrixCSR:
+        return cls._csr_from_dataset(dataset)
+
+    def _compute_weights(self, source, target, relative: bool) -> None:
+        source, target = convert_to_match(source, target)
+        source_index, target_index, weight_values = target.intersection_length(
+            source, relative=relative
+        )
+        self._weights = MatrixCSR.from_triplet(
+            target_index, source_index, weight_values, n=target.size, m=source.size
+        )
+        return
+
+    @classmethod
+    def from_weights(
+        cls,
+        weights: xr.Dataset,
+        target: Union["xugrid.Ugrid2d", xr.DataArray, xr.Dataset],
+        method: Union[str, Callable] = "mean",
+    ):
+        instance = super().from_weights(weights, target)
+        instance._setup_regrid(method)
+        return instance

--- a/xugrid/regrid/network.py
+++ b/xugrid/regrid/network.py
@@ -1,0 +1,36 @@
+import xugrid as xu
+from xugrid import Ugrid1d
+
+
+class Network2d:
+    def __init__(self, obj):
+        # TODO: do not omit type check on grid!
+        if isinstance(obj, (xu.UgridDataArray, xu.UgridDataset)):
+            self.ugrid_topology = obj.grid
+        elif isinstance(obj, Ugrid1d):
+            self.ugrid_topology = obj
+        else:
+            options = {"Ugrid1d", "UgridDataArray", "UgridDataset"}
+            raise TypeError(
+                f"Expected one of {options}, received: {type(obj).__name__}"
+            )
+
+    @property
+    def ndim(self):
+        return 1
+
+    @property
+    def dims(self):
+        return (self.ugrid_topology.edge_dimension,)
+
+    @property
+    def shape(self):
+        return (self.ugrid_topology.n_edge,)
+
+    @property
+    def size(self):
+        return self.ugrid_topology.n_edge
+
+    @property
+    def length(self):
+        return self.ugrid_topology.length

--- a/xugrid/regrid/network.py
+++ b/xugrid/regrid/network.py
@@ -1,5 +1,4 @@
 import xugrid as xu
-from xugrid import Ugrid1d
 
 
 class Network2d:
@@ -7,7 +6,7 @@ class Network2d:
         # TODO: do not omit type check on grid!
         if isinstance(obj, (xu.UgridDataArray, xu.UgridDataset)):
             self.ugrid_topology = obj.grid
-        elif isinstance(obj, Ugrid1d):
+        elif isinstance(obj, xu.Ugrid1d):
             self.ugrid_topology = obj
         else:
             options = {"Ugrid1d", "UgridDataArray", "UgridDataset"}

--- a/xugrid/regrid/regridder.py
+++ b/xugrid/regrid/regridder.py
@@ -232,7 +232,7 @@ class BaseRegridder(abc.ABC):
             source_dims = ("y", "x")
         elif isinstance(data, UgridDataArray):
             obj = data.ugrid.obj
-            source_dims = (data.ugrid.grid.face_dimension,)
+            source_dims = (data.ugrid.grid.core_dimension,)
         else:
             raise TypeError(
                 f"Expected DataArray or UgridDataAray, received: {type(data).__name__}"

--- a/xugrid/regrid/unstructured.py
+++ b/xugrid/regrid/unstructured.py
@@ -63,6 +63,7 @@ class UnstructuredGrid2d:
     """
 
     def __init__(self, obj):
+        # TODO: do not omit type check on grid!
         if isinstance(obj, (xu.UgridDataArray, xu.UgridDataset)):
             self.ugrid_topology = obj.grid
         elif isinstance(obj, Ugrid2d):
@@ -190,6 +191,20 @@ class UnstructuredGrid2d:
 
         order = np.argsort(target_index)
         return source_index[order], target_index[order], weights[order]
+
+    def intersection_length(self, other: "xu.regrid.network.Network2d", relative: bool):
+        (
+            target_index,
+            source_index,
+            intersections,
+        ) = self.ugrid_topology.celltree.intersect_edges(
+            other.ugrid_topology.edge_node_coordinates
+        )
+        order = np.argsort(target_index)
+        length = np.linalg.norm(np.diff(intersections, axis=1), axis=-1)[:, 0]
+        if relative:
+            length /= other.length[source_index]
+        return target_index[order], source_index[order], length[order]
 
     def to_dataset(self, name: str):
         ds = self.ugrid_topology.rename(name).to_dataset()

--- a/xugrid/regrid/unstructured.py
+++ b/xugrid/regrid/unstructured.py
@@ -200,7 +200,7 @@ class UnstructuredGrid2d:
         ) = self.ugrid_topology.celltree.intersect_edges(
             other.ugrid_topology.edge_node_coordinates
         )
-        order = np.argsort(target_index)
+        order = np.argsort(source_index)
         length = np.linalg.norm(np.diff(intersections, axis=1), axis=-1)[:, 0]
         if relative:
             length /= other.length[source_index]

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -289,6 +289,13 @@ class Ugrid1d(AbstractUgrid):
             self.edge_dimension: self.edge_coordinates,
         }
 
+    @property
+    def length(self):
+        return np.linalg.norm(
+            np.diff(self.edge_node_coordinates, axis=1),
+            axis=1,
+        )
+
     def get_coordinates(self, dim: str) -> FloatArray:
         """Return the coordinates for the specified UGRID dimension."""
         if dim == self.node_dimension:


### PR DESCRIPTION
Adds NetworkGridder, currently only supports gridding Ugrid1d networks to unstructured grids, as the scope was getting too large, and I didn't know an easy way how to implement a StructuredGrid2d.intersection_length method.