### PR TITLE
Issue #353 ilu preconditioner zero division error

### DIFF
--- a/tests/test_ugrid_dataset.py
+++ b/tests/test_ugrid_dataset.py
@@ -1533,6 +1533,39 @@ def test_laplace_interpolate_1d():
     assert np.allclose(actual, 1.0)
 
 
+def test_laplace_interpolate_1d__disconnected():
+    """
+    Test laplace_interpolate on a 1D grid with disconnected edges. Should throw
+    no ZeroDivisionErrors.
+    """
+    xy = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [3.0, 3.0],
+            [4.0, 4.0],
+        ]
+    )
+    grid = xugrid.Ugrid1d(
+        node_x=xy[:, 0],
+        node_y=xy[:, 1],
+        fill_value=-1,
+        edge_node_connectivity=np.array([[0, 1], [1, 2], [3, 4]]),
+    )
+    ds = grid.to_dataset()
+    ds["a1d"] = xr.DataArray(
+        [1.0, np.nan, 0.0, np.nan, np.nan], dims=[grid.node_dimension]
+    )
+    ds["b1d"] = xr.DataArray([1.0, 2.0, 3.0], dims=[grid.edge_dimension])
+    uda = xugrid.UgridDataset(ds)["a1d"]
+
+    actual = uda.ugrid.laplace_interpolate(direct_solve=False)
+    assert isinstance(actual, xugrid.UgridDataArray)
+    np.testing.assert_allclose(actual[:3], np.array([1.0, 0.5, 0.0]))
+    np.testing.assert_allclose(actual[3:], 0.0)
+
+
 def test_interpolate_na_1d():
     uda = ugrid1d_ds()["a1d"]
     with pytest.raises(ValueError, match='"abc" is not a valid interpolator.'):

--- a/xugrid/ugrid/interpolate.py
+++ b/xugrid/ugrid/interpolate.py
@@ -64,7 +64,9 @@ def _update(ilu: ILU0Preconditioner, A: MatrixCSR, delta: float, relax: float):
         diag = ilu.work[i]
         multiplier = (1.0 + delta) * diag - (relax * rs)
         # Work around a zero-valued pivot
-        if (np.sign(multiplier) != np.sign(diag)) or (multiplier == 0):
+        if multiplier == 0:
+            multiplier = 1e-6
+        elif np.sign(multiplier) != np.sign(diag):
             multiplier = np.sign(diag) * 1.0e-6
         ilu.diagonal[i] = 1.0 / multiplier
 

--- a/xugrid/ugrid/interpolate.py
+++ b/xugrid/ugrid/interpolate.py
@@ -63,7 +63,8 @@ def _update(ilu: ILU0Preconditioner, A: MatrixCSR, delta: float, relax: float):
 
         diag = ilu.work[i]
         multiplier = (1.0 + delta) * diag - (relax * rs)
-        # Work around a zero-valued pivot
+        # Work around a zero-valued pivot and make sure the multiplier hasn't
+        # changed sign.
         if multiplier == 0:
             multiplier = 1e-6
         elif np.sign(multiplier) != np.sign(diag):


### PR DESCRIPTION
Fix issue #353

Fix ZeroDivisionError, added a unittest for it. Also I noticed that for some reason the Laplace Interpolate would do the following thing:

```[1.0, np.nan, 1.0] -> [np.nan, np.nan, np.nan]```

Hence why I resorted to interpolating from 1 to 0 in the unittest. Will be picked up upon in a follow-up issue.