### PR TITLE
Explicitly set ``compat`` setting for calls to merge

### DIFF
--- a/xugrid/core/dataset_accessor.py
+++ b/xugrid/core/dataset_accessor.py
@@ -299,7 +299,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         for grid in self.grids:
             xx, yy, index = grid.rasterize(resolution, self.total_bounds)
             datasets.append(self._raster(xx, yy, index))
-        return xr.merge(datasets)
+        return xr.merge(datasets, compat="override")
 
     def rasterize_like(self, other: Union[xr.DataArray, xr.Dataset]) -> xr.Dataset:
         """
@@ -323,7 +323,7 @@ class UgridDatasetAccessor(AbstractUgridAccessor):
         for grid in self.grids:
             xx, yy, index = grid.rasterize_like(x, y)
             datasets.append(self._raster(xx, yy, index))
-        return xr.merge(datasets)
+        return xr.merge(datasets, compat="override")
 
     def to_periodic(self):
         """

--- a/xugrid/regrid/regridder.py
+++ b/xugrid/regrid/regridder.py
@@ -264,7 +264,7 @@ class BaseRegridder(abc.ABC):
         )
         source_ds = self._source.to_dataset("__source")
         target_ds = self._target.to_dataset("__target")
-        return xr.merge((weights_ds, source_ds, target_ds))
+        return xr.merge((weights_ds, source_ds, target_ds), compat="override")
 
     def weights_as_dataframe(self) -> pd.DataFrame:
         """

--- a/xugrid/regrid/structured.py
+++ b/xugrid/regrid/structured.py
@@ -603,7 +603,7 @@ class StructuredGrid2d(StructuredGrid1d):
     def to_dataset(self, name: str) -> xr.Dataset:
         ds_x = self.xbounds.to_dataset(name)
         ds_y = self.ybounds.to_dataset(name)
-        ds = xr.merge([ds_x, ds_y])
+        ds = xr.merge([ds_x, ds_y], compat="override")
         ds[name + "_type"] = xr.DataArray(-1, attrs={"type": "StructuredGrid2d"})
         return ds
 

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -275,7 +275,7 @@ class Ugrid1d(AbstractUgrid):
         if self._dataset:
             dataset = dataset.merge(self._dataset, compat="override")
         if other is not None:
-            dataset = dataset.merge(other, compat="no_conflicts")
+            dataset = dataset.merge(other, compat="override")
         if node_x not in dataset or node_y not in dataset:
             dataset = self.assign_node_coords(dataset)
         if optional_attributes:

--- a/xugrid/ugrid/ugrid1d.py
+++ b/xugrid/ugrid/ugrid1d.py
@@ -275,7 +275,7 @@ class Ugrid1d(AbstractUgrid):
         if self._dataset:
             dataset = dataset.merge(self._dataset, compat="override")
         if other is not None:
-            dataset = dataset.merge(other)
+            dataset = dataset.merge(other, compat="no_conflicts")
         if node_x not in dataset or node_y not in dataset:
             dataset = self.assign_node_coords(dataset)
         if optional_attributes:


### PR DESCRIPTION
I'm doing multiple calls to the regridder in iMOD Python, this prints the following warning multiple times:

```
FutureWarning: In a future version of xarray the default value for compat will change from compat='no_conflicts' to compat='override'. This is likely to lead to different results when combining overlapping variables with the same name. To opt in to new defaults and get rid of these warnings now use `set_options(use_new_combine_kwarg_defaults=True) or set compat explicitly.
  ds = xr.merge([ds_x, ds_y])
```

Probably good to explicitly set the ``compat`` setting explicitly.