### PR TITLE
Fix `Ugrid2d.clip_box` ignoring its bounding box arguments (fixes #440)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,13 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Unreleased
 ----------
 
+Fixed
+~~~~~
+
+- :meth:`xugrid.Ugrid2d.clip_box` no longer overwrites its bounding box
+  arguments with the grid's own bounds, which previously made it return the
+  full mesh regardless of the requested box.
+
 [0.15.2] 2026-04-20
 -------------------
 

--- a/tests/test_ugrid2d.py
+++ b/tests/test_ugrid2d.py
@@ -722,6 +722,20 @@ def test_locate_bounding_box():
     assert np.allclose(faces, [1, 3])
 
 
+def test_clip_box():
+    grid = grid2d()
+    # A bounding box smaller than the grid must actually clip, rather than
+    # return the full mesh (https://github.com/Deltares/xugrid/issues/440).
+    actual = grid.clip_box(1.25, 0.25, 2.5, 1.5)
+    expected = grid.topology_subset(np.array([1, 3]))
+    assert actual.n_face == 2
+    assert np.array_equal(
+        actual.face_node_connectivity, expected.face_node_connectivity
+    )
+    # Clipping by the full bounds returns the entire mesh unchanged.
+    assert grid.clip_box(*grid.bounds) is grid
+
+
 def test_compute_barycentric_weights():
     grid = grid2d()
     xy = np.array(

--- a/xugrid/ugrid/ugrid2d.py
+++ b/xugrid/ugrid/ugrid2d.py
@@ -1217,7 +1217,6 @@ class Ugrid2d(AbstractUgrid):
         xmax: float,
         ymax: float,
     ):
-        xmin, ymin, xmax, ymax = self.bounds
         bounds = [xmin, ymin, xmax, ymax]
         face_index = self.locate_bounding_box(*bounds)
         return self.topology_subset(face_index)


### PR DESCRIPTION
## Problem

`Ugrid2d.clip_box` is a no-op: it always returns the full mesh, ignoring the requested box.

```python
def clip_box(self, xmin, ymin, xmax, ymax):
    xmin, ymin, xmax, ymax = self.bounds   # <- discards the caller's arguments
    bounds = [xmin, ymin, xmax, ymax]
    face_index = self.locate_bounding_box(*bounds)
    return self.topology_subset(face_index)
```

The first line reassigns the four parameters from `self.bounds` (the grid's own full extent), so `locate_bounding_box` always receives the entire grid and no clipping happens.

## Fix

Drop the overwriting line so the supplied bounds are used. For reference, the sibling implementations already handle their arguments correctly: `Ugrid1d.clip_box` forwards them straight to `.sel`, and `Ugrid2d._sel_box` only uses `self.bounds` as a *fallback* for open-ended slices (via `numeric_bound`), not as an unconditional override.

## Verification

- Before: `clip_box(1.25, 0.25, 2.5, 1.5)` on the test grid returns all 4 faces.
- After: it returns the 2 faces inside the box (matching `locate_bounding_box`), while `clip_box(*grid.bounds)` still returns the whole mesh.
- Added `test_clip_box` (fails without the fix, passes with it); existing selection/subset tests still pass.

Fixes #440.